### PR TITLE
LastSessionStats and LastSessionEditCount changes

### DIFF
--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/LastSessionEditCount.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/LastSessionEditCount.cs
@@ -35,7 +35,11 @@ namespace CVChatbot.Bot.ChatbotActions.Commands
                     .Groups[1]
                     .Value
                     .Parse<int>();
-
+                if (newReviewCount < 0)
+                {
+                    chatRoom.PostReplyOrThrow(incommingChatMessage, "New review count cannot be negative.");
+                    return;
+                }
                 var previousReviewCount = lastSession.ItemsReviewed;
                 lastSession.ItemsReviewed = newReviewCount;
 

--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/LastSessionEditCount.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/LastSessionEditCount.cs
@@ -35,6 +35,7 @@ namespace CVChatbot.Bot.ChatbotActions.Commands
                     .Groups[1]
                     .Value
                     .Parse<int>();
+
                 if (newReviewCount < 0)
                 {
                     chatRoom.PostReplyOrThrow(incommingChatMessage, "New review count cannot be negative.");
@@ -56,7 +57,7 @@ namespace CVChatbot.Bot.ChatbotActions.Commands
                         lastSession.SessionEnd.Value.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss 'UTC'"),
                         previousReviewCount.HasValue
                             ? previousReviewCount.Value.ToString()
-                            : "[Not Set]", 
+                            : "[Not Set]",
                         lastSession.ItemsReviewed.Value);
 
                 db.SaveChanges();

--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/LastSessionStats.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/LastSessionStats.cs
@@ -45,7 +45,16 @@ namespace CVChatbot.Bot.ChatbotActions.Commands
                 }
                 else
                 {
-                    var averageTimePerReview = new TimeSpan(sessionLength.Ticks / (lastSession.ItemsReviewed.Value));
+                    TimeSpan averageTimePerReview;
+                    var itemsReviewed = lastSession.ItemsReviewed.Value;
+                    if (itemsReviewed != 0)
+                    {
+                        averageTimePerReview = new TimeSpan(sessionLength.Ticks / (itemsReviewed));
+                    }
+                    else
+                    {
+                        averageTimePerReview = new TimeSpan(0);
+                    }
 
                     statMessage += "You reviewed {2} items, averaging a review every {3}.";
                     statMessage = statMessage.FormatSafely(


### PR DESCRIPTION
LastSessionEditCount now doesn't accept a negative number anymore, and
LastSessionStats doesn't throw an exception anymore when the number of
items reviewed is 0.