### PR TITLE
Add anchors for StartingSession

### DIFF
--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/StartingSession.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/StartingSession.cs
@@ -39,7 +39,7 @@ namespace CVChatbot.Bot.ChatbotActions.Commands
 
         protected override string GetRegexMatchingPattern()
         {
-            return @"(?:i'?m )?start(ing|ed)(?: now)?";
+            return @"^(?:i'?m )?start(ing|ed)(?: now)?$";
         }
 
         public override string GetActionName()


### PR DESCRIPTION
If they are not there, the bot crashes if your "ping reviewers" message
contains "start".