### PR TITLE
StartingSession regex

### DIFF
--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/StartingSession.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/StartingSession.cs
@@ -39,7 +39,7 @@ namespace CVChatbot.Bot.ChatbotActions.Commands
 
         protected override string GetRegexMatchingPattern()
         {
-            return @"(?:i'?m )?start(ing|ed)(?: now)?";
+            return @"^(?:i'?m )?start(ing|ed)(?: now)?$";
         }
 
         public override string GetActionName()

--- a/CVChatbot/Sql/06 - GetPingReviewersRecipientList function.sql
+++ b/CVChatbot/Sql/06 - GetPingReviewersRecipientList function.sql
@@ -1,0 +1,33 @@
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+
+CREATE FUNCTION GetPingReviewersRecipientList 
+(
+	@MaxDaysBack int,
+	@ChatProfileIdRequestingInform int
+)
+RETURNS 
+@Return TABLE 
+(
+	ChatProfileId int not null
+)
+AS
+BEGIN
+	
+	insert into @Return(ChatProfileId)
+		select
+			ru.ChatProfileId
+		from ReviewSession rs
+		inner join RegisteredUser ru on rs.RegisteredUserId = ru.Id
+		where
+			ru.ChatProfileId != @ChatProfileIdRequestingInform and
+			rs.SessionStart is not null and
+			rs.SessionEnd > dateadd(day, -@MaxDaysBack, SYSDATETIMEOFFSET())
+		group by
+			ru.ChatProfileId
+	
+	RETURN 
+END
+GO


### PR DESCRIPTION
If they are not there, the bot crashes if your "ping reviewers" message
contains "start".