### PR TITLE
Issue 75

### DIFF
--- a/CVChatbot/CVChatbot.Bot/SEDEAccessor.cs
+++ b/CVChatbot/CVChatbot.Bot/SEDEAccessor.cs
@@ -1,4 +1,4 @@
-﻿﻿using System;
+﻿using System;
 using System.IO;
 using System.Linq;
 using System.Collections.Generic;
@@ -16,9 +16,9 @@ namespace CVChatbot
     public static class SedeAccessor
     {
         /// <summary>
-        /// The last CSV revision ID of when fresh tags were fetched.
+        /// The last url with revision.
         /// </summary>
-        private static string lastCsvRevID;
+        private static string lastRevision;
 
         /// <summary>
         /// The last time fresh tag data was fetched.
@@ -85,10 +85,10 @@ namespace CVChatbot
 
                 var currentID = "";
 
-                if ((currentID = Client.GetSedeQueryCsvRevisionId("http://data.stackexchange.com/stackoverflow")) != lastCsvRevID)
+                if ((currentID = Client.GetSedeQueryRunUrl(236526)) != lastRevision)
                 {
-                    lastCsvRevID = currentID;
-                    tags = Client.GetTags();
+                    lastRevision = currentID;
+                    tags = Client.GetTags(lastRevision);
                 }
 
                 lastRevIdCheckTime = DateTime.UtcNow;

--- a/CVChatbot/CVChatbot.Bot/SEDEAccessor.cs
+++ b/CVChatbot/CVChatbot.Bot/SEDEAccessor.cs
@@ -16,9 +16,9 @@ namespace CVChatbot
     public static class SedeAccessor
     {
         /// <summary>
-        /// The last url with revision.
+        /// The last CSV revision ID of when fresh tags were fetched.
         /// </summary>
-        private static string lastRevision;
+        private static string lastCsvRevID;
 
         /// <summary>
         /// The last time fresh tag data was fetched.
@@ -85,10 +85,10 @@ namespace CVChatbot
 
                 var currentID = "";
 
-                if ((currentID = Client.GetSedeQueryRunUrl(236526)) != lastRevision)
+                if ((currentID = Client.GetSedeQueryCsvRevisionId("http://data.stackexchange.com/stackoverflow")) != lastCsvRevID)
                 {
-                    lastRevision = currentID;
-                    tags = Client.GetTags(lastRevision);
+                    lastCsvRevID = currentID;
+                    tags = Client.GetTags();
                 }
 
                 lastRevIdCheckTime = DateTime.UtcNow;

--- a/CVChatbot/CVChatbot.Bot/SEDEAccessor.cs
+++ b/CVChatbot/CVChatbot.Bot/SEDEAccessor.cs
@@ -16,9 +16,9 @@ namespace CVChatbot
     public static class SedeAccessor
     {
         /// <summary>
-        /// The last CSV revision ID of when fresh tags were fetched.
+        /// The last url with revision.
         /// </summary>
-        private static string lastCsvRevID;
+        private static string lastRevision;
 
         /// <summary>
         /// The last time fresh tag data was fetched.
@@ -85,10 +85,10 @@ namespace CVChatbot
 
                 var currentID = "";
 
-                if ((currentID = Client.GetSedeQueryCsvRevisionId("http://data.stackexchange.com/stackoverflow")) != lastCsvRevID)
+                if ((currentID = Client.GetSedeQueryRunUrl(236526)) != lastRevision)
                 {
-                    lastCsvRevID = currentID;
-                    tags = Client.GetTags();
+                    lastRevision = currentID;
+                    tags = Client.GetTags(lastRevision);
                 }
 
                 lastRevIdCheckTime = DateTime.UtcNow;

--- a/CVChatbot/CVChatbot.Bot/SedeClient.cs
+++ b/CVChatbot/CVChatbot.Bot/SedeClient.cs
@@ -7,8 +7,6 @@ using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 using System.Text.RegularExpressions;
-using System.Runtime.Serialization.Json;
-using System.Threading;
 
 namespace CVChatbot.Bot
 {
@@ -20,18 +18,12 @@ namespace CVChatbot.Bot
     {
         # region Private fields/const(s).
 
-        const string host = "http://data.stackexchange.com";
         const string baseUrl = "http://data.stackexchange.com/stackoverflow";
-        const string baseUrlFormat = "http://data.stackexchange.com{0}";
-        const string baseUrlJobFormat = "http://data.stackexchange.com/query/job/{0}";
-        const string baseUrlQueryFormat = "http://data.stackexchange.com/stackoverflow/query/{0}";
 
         /// <summary>
         /// Notice that this baby is AppDomain wide used as it is static.
         /// </summary>
         private readonly static CookieContainer cookies = new CookieContainer();
-
-        private readonly static DataContractJsonSerializer ser = new DataContractJsonSerializer(typeof(JobResult));
 
         private bool disposed;
         # endregion
@@ -76,55 +68,93 @@ namespace CVChatbot.Bot
             Dispose(true);
         }
 
-
-        
         /// <summary>
         /// This runs the Sede Query and gives us the revision Id of the CSV DownloadLink
         /// </summary>
         /// <param name="baseUrl">Where sede and the query live.</param>
         /// <returns>The revision.</returns>
-        public string GetSedeQueryRunUrl(int queryid)
+        public string GetSedeQueryCsvRevisionId(string baseUrl)
         {
-            // get the initial query page 
-            var data = Get(String.Format(baseUrlQueryFormat,queryid));
-            return  GetFormActionUrl(data);
-        }
+            ThrowWhen.IsNullOrEmpty(baseUrl, "baseUrl");
 
-        
+            var data = Get(baseUrl + "/query/236526/tags-that-can-be-cleared-of-votes#");
+            data = data.Remove(0, data.Length - 3000); // Footer averages around 2,500 chars, so lets say 3K just to be safe.
+
+            // This regex could be turned into a private static variable which would then allow us
+            // to instantiate it with the RegexOptions.Complied flag for even greater performance.
+            var matches = Regex.Matches(data, "(?is)\"revisionId\":\\s\\d+", RegexOptions.CultureInvariant);
+
+            if (matches.Count != 1)
+            {
+                throw new Exception("Couldn't find CSV revision ID.");
+            }
+
+            foreach (Match match in matches)
+            {
+                var matchStr = match.Value;
+                var revId = new string(matchStr.Where(Char.IsDigit).ToArray());
+                return revId;
+            }
+
+            throw new Exception("Couldn't find CSV revision ID.");
+        }
 
         /// <summary>
         /// Retrieves from the sede query the results.
         /// </summary>
         /// <returns>The tagname and the count in a dictionary.</returns>
-        public Dictionary<string, int> GetTags(string url)
+        public Dictionary<string, int> GetTags()
         {
-            ThrowWhen.IsNullOrEmpty(url, "action url");
             // Get in to run first.
-            var jobResult = GetQueryResult(url);
+            string id = GetSedeQueryCsvRevisionId(baseUrl);
 
-            return GetTags(jobResult);
+            return GetTags(id);
         }
 
         /// <summary>
         /// Retrieves from the sede query the results.
         /// </summary>
         /// <returns>The tagname and the count in a dictionary.</returns>
-        public Dictionary<string, int> GetTags(JobResult jobResult)
+        public Dictionary<string, int> GetTags(string csvRevId)
         {
-            if (jobResult == null)
+            ThrowWhen.IsNullOrEmpty(csvRevId, "csvRevId");
+
+            // For collecting the result.
+            Dictionary<string, int> tags = null;
+
+            // This gets a text/csv content
+            // tag, count
+            // "java", "200"
+            // "php", "120"
+            var csv = GetCSVQuery(baseUrl + "/csv/" + csvRevId);
+
+            tags = new Dictionary<string, int>();
+            var header = true; // Skip the header.
+
+            // Split the returned string on each line.
+            foreach (var line in csv.Split(new string[] { "\r\n" }, StringSplitOptions.None))
             {
-                return new Dictionary<string, int> { { "No tags found", 42 } };
+                if (header)
+                {
+                    header = false;
+                }
+                else
+                {
+                    // Split a line in fields.
+                    var fields = line.Split(',');
+
+                    // First field is the tag enclosed in " which we remove.
+                    var tag = fields[0].Replace("\"", "");
+
+                    // Parse the count from the second field.
+                    int cnt;
+                    Int32.TryParse(fields[1].Replace("\"", ""), out cnt);
+
+                    tags.Add(tag, cnt);
+                }
             }
 
-            var dict = new Dictionary<string, int>();
-            foreach (object[] row in jobResult.resultSets[0].rows)
-            {
-                int value;
-                Int32.TryParse(row[1].ToString(), out value);
-                dict.Add(row[0].ToString(), value);
-            }
-
-            return dict;
+            return tags;
         }
         # endregion
 
@@ -133,136 +163,20 @@ namespace CVChatbot.Bot
         # region Private methods.
 
         /// <summary>
-        /// formaction is the url posted to if the query is run. This includes the revision
-        /// </summary>
-        /// <param name="data"></param>
-        /// <returns></returns>
-        private string GetFormActionUrl(string data)
-        {
-            const string formTag = @"<form id=""runQueryForm"" action=""";
-            // no fancy regex here
-            string result = null;
-            var postUrlAction = data.IndexOf(formTag);
-            if (postUrlAction > -1)
-            {
-                var closingQuote = data.IndexOf('"', postUrlAction + formTag.Length);
-                if (closingQuote > -1)
-                {
-                    result = data.Substring(postUrlAction + formTag.Length, closingQuote - (postUrlAction + formTag.Length));
-                }
-            }
-            return result;
-        }
-
-        /// <summary>
-        /// the query result is retrieved by POSTING the formaction with no data
-        /// </summary>
-        /// <param name="url">the formaction url</param>
-        /// <returns>a jobresult</returns>
-        private JobResult GetQueryResult(string url)
-        {
-            JobResult jobResult = null;
-            using (var jobStream = PostStream(String.Format(baseUrlFormat, url), null))
-            {
-                jobResult = (JobResult)ser.ReadObject(jobStream);
-                if (jobResult.captcha)
-                {
-                    Console.WriteLine("captcha requested! not logged in?");
-                }
-                else
-                {
-                    // if a job is started on the server 
-                    // we have to poll for the result
-                    // this call might block while polling but 
-                    // if the result is already there we return immediately
-                    jobResult = GetQueryResultByPolling(jobResult);
-
-                    if (jobResult.resultSets != null
-                        && jobResult.resultSets.Length > 0)
-                    {
-                        Console.WriteLine(jobResult.resultSets[0].rows.Length);
-                    }
-                    else
-                    {
-                        Console.WriteLine("Hmm, no result sets...");
-                        // maybe an eror
-                        Console.WriteLine(jobResult.error);
-                    }
-                }
-            }
-            return jobResult;
-        }
-
-        //this call is blocking, while doing work on a timer thread
-        private JobResult GetQueryResultByPolling(JobResult jobResult)
-        {
-            // we need to poll
-            if (jobResult.running)
-            {
-                var serializeTimer = new Object();
-                var done = new ManualResetEvent(false); // wait handle
-                // we use a timer that runs every second
-                using (var timer = new Timer((state) =>
-                {
-                    // make sure we are single threaded
-                    lock (serializeTimer)
-                    {
-                        // if we are not running, don't override our result
-                        if (jobResult.running)
-                        {
-                            // poll result
-                            Console.WriteLine(jobResult.job_id);
-                            using (var pollStream = GetAsStream(String.Format(baseUrlJobFormat, jobResult.job_id)))
-                            {
-                                jobResult = (JobResult)ser.ReadObject(pollStream);
-                            }
-                        }
-                        // if we have a result, get out!
-                        if (!jobResult.running)
-                        {
-                            done.Set(); // signal main thread
-                        }
-                    }
-                }
-                    ))
-                {
-                    timer.Change(100, 1000);
-
-                    bool signaled = done.WaitOne(new TimeSpan(0, 1, 0));
-                    if (!signaled)
-                    {
-                        Console.WriteLine("no response in 1 minute");
-                    }
-                }
-            }
-            return jobResult;
-        }
-
-        /// <summary>
         /// GET from the url whatever is returned as a string.
         /// This method uses/fills the shared CookieContainer.
         /// </summary>
         private string Get(string url)
-        {
-            using (var sr = new StreamReader(GetAsStream(url)))
-            {
-                return sr.ReadToEnd();
-            }
-        }
-
-        /// <summary>
-        /// ge the raw stream from the http response
-        /// </summary>
-        /// <param name="url"></param>
-        /// <returns>the stream</returns>
-        private static Stream GetAsStream(string url)
         {
             var req = HttpWebRequest.CreateHttp(url);
             req.Method = "GET";
             req.AllowAutoRedirect = true;
             req.CookieContainer = cookies;
             var resp = (HttpWebResponse)req.GetResponse();
-            return resp.GetResponseStream();
+            using (var sr = new StreamReader(resp.GetResponseStream()))
+            {
+                return sr.ReadToEnd();
+            }
         }
 
         /// <summary>
@@ -278,44 +192,22 @@ namespace CVChatbot.Bot
         /// </summary>
         private string Post(string url, string data)
         {
-            using (var resp = PostStream(url, data))
-            {
-                using (var sr = new StreamReader(resp))
-                {
-                    return sr.ReadToEnd();
-                }
-            }
-        }
-
-        /// <summary>
-        /// Posts and returns the stream
-        /// </summary>
-        /// <param name="url"></param>
-        /// <param name="data"></param>
-        /// <returns></returns>
-        private static Stream PostStream(string url, string data)
-        {
             var req = HttpWebRequest.CreateHttp(url);
             req.Method = "POST";
             req.CookieContainer = cookies;
-            if (!String.IsNullOrEmpty(data))
+            req.ContentType = "application/x-www-form-urlencoded";
+            req.ContentLength = data.Length;
+            using (var sw = new StreamWriter(req.GetRequestStream()))
             {
-                req.ContentType = "application/x-www-form-urlencoded";
-                req.ContentLength = data.Length;
-                using (var sw = new StreamWriter(req.GetRequestStream()))
-                {
-                    sw.Write(data);
-                    sw.Flush();
-                }
-            }
-            else
-            {
-                req.ContentLength = 0;
+                sw.Write(data);
+                sw.Flush();
             }
             var resp = (HttpWebResponse)req.GetResponse();
-            return resp.GetResponseStream();
+            using (var sr = new StreamReader(resp.GetResponseStream()))
+            {
+                return sr.ReadToEnd();
+            }
         }
-
 
 
         /// <summary>
@@ -327,12 +219,10 @@ namespace CVChatbot.Bot
         private void SEOpenIDLogin(string email, string password)
         {
             // Do a Get to retrieve the cookies.
-            var start = Post("http://data.stackexchange.com/user/authenticate?returnurl=/", "openid_identifier=https%3A%2F%2Fopenid.stackexchange.com%2F");
+            var start = Get("https://openid.stackexchange.com/account/login");
 
-            var html = CQ.Create(start);
-            // If we find no fkey or session in html.
-            string fkey = html.GetInputValue("fkey");
-            string session = html.GetInputValue("session");
+            // If we find no fkey in html.
+            string fkey = CQ.Create(start).GetInputValue("fkey");
 
             // We are already logged in.
             if (!String.IsNullOrEmpty(fkey))
@@ -340,8 +230,7 @@ namespace CVChatbot.Bot
                 // We found an fkey, use it to login via openid.
                 var data = "email=" + Uri.EscapeDataString(email) +
                            "&password=" + Uri.EscapeDataString(password) +
-                           "&fkey=" + fkey +
-                           "&session=" + session;
+                           "&fkey=" + fkey;
 
                 var res = Post("https://openid.stackexchange.com/account/login/submit", data);
 
@@ -353,24 +242,5 @@ namespace CVChatbot.Bot
         }
 
         # endregion
-
-        #region serialization classes
-
-        public class ResultSet
-        {
-            public object[] rows { get; set; }
-        }
-
-        public class JobResult
-        {
-            public string line { get; set; }
-            public string error { get; set; }
-            public bool captcha { get; set; }
-            public bool running { get; set; }
-            public string job_id { get; set; }
-            public int revisionId { get; set; }
-            public ResultSet[] resultSets { get; set; }
-        }
-        #endregion 
     }
 }

--- a/CVChatbot/CVChatbot.Bot/SedeClient.cs
+++ b/CVChatbot/CVChatbot.Bot/SedeClient.cs
@@ -7,6 +7,8 @@ using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 using System.Text.RegularExpressions;
+using System.Runtime.Serialization.Json;
+using System.Threading;
 
 namespace CVChatbot.Bot
 {
@@ -18,12 +20,18 @@ namespace CVChatbot.Bot
     {
         # region Private fields/const(s).
 
+        const string host = "http://data.stackexchange.com";
         const string baseUrl = "http://data.stackexchange.com/stackoverflow";
+        const string baseUrlFormat = "http://data.stackexchange.com{0}";
+        const string baseUrlJobFormat = "http://data.stackexchange.com/query/job/{0}";
+        const string baseUrlQueryFormat = "http://data.stackexchange.com/stackoverflow/query/{0}";
 
         /// <summary>
         /// Notice that this baby is AppDomain wide used as it is static.
         /// </summary>
         private readonly static CookieContainer cookies = new CookieContainer();
+
+        private readonly static DataContractJsonSerializer ser = new DataContractJsonSerializer(typeof(JobResult));
 
         private bool disposed;
         # endregion
@@ -68,93 +76,55 @@ namespace CVChatbot.Bot
             Dispose(true);
         }
 
+
+        
         /// <summary>
         /// This runs the Sede Query and gives us the revision Id of the CSV DownloadLink
         /// </summary>
         /// <param name="baseUrl">Where sede and the query live.</param>
         /// <returns>The revision.</returns>
-        public string GetSedeQueryCsvRevisionId(string baseUrl)
+        public string GetSedeQueryRunUrl(int queryid)
         {
-            ThrowWhen.IsNullOrEmpty(baseUrl, "baseUrl");
-
-            var data = Get(baseUrl + "/query/236526/tags-that-can-be-cleared-of-votes#");
-            data = data.Remove(0, data.Length - 3000); // Footer averages around 2,500 chars, so lets say 3K just to be safe.
-
-            // This regex could be turned into a private static variable which would then allow us
-            // to instantiate it with the RegexOptions.Complied flag for even greater performance.
-            var matches = Regex.Matches(data, "(?is)\"revisionId\":\\s\\d+", RegexOptions.CultureInvariant);
-
-            if (matches.Count != 1)
-            {
-                throw new Exception("Couldn't find CSV revision ID.");
-            }
-
-            foreach (Match match in matches)
-            {
-                var matchStr = match.Value;
-                var revId = new string(matchStr.Where(Char.IsDigit).ToArray());
-                return revId;
-            }
-
-            throw new Exception("Couldn't find CSV revision ID.");
+            // get the initial query page 
+            var data = Get(String.Format(baseUrlQueryFormat,queryid));
+            return  GetFormActionUrl(data);
         }
+
+        
 
         /// <summary>
         /// Retrieves from the sede query the results.
         /// </summary>
         /// <returns>The tagname and the count in a dictionary.</returns>
-        public Dictionary<string, int> GetTags()
+        public Dictionary<string, int> GetTags(string url)
         {
+            ThrowWhen.IsNullOrEmpty(url, "action url");
             // Get in to run first.
-            string id = GetSedeQueryCsvRevisionId(baseUrl);
+            var jobResult = GetQueryResult(url);
 
-            return GetTags(id);
+            return GetTags(jobResult);
         }
 
         /// <summary>
         /// Retrieves from the sede query the results.
         /// </summary>
         /// <returns>The tagname and the count in a dictionary.</returns>
-        public Dictionary<string, int> GetTags(string csvRevId)
+        public Dictionary<string, int> GetTags(JobResult jobResult)
         {
-            ThrowWhen.IsNullOrEmpty(csvRevId, "csvRevId");
-
-            // For collecting the result.
-            Dictionary<string, int> tags = null;
-
-            // This gets a text/csv content
-            // tag, count
-            // "java", "200"
-            // "php", "120"
-            var csv = GetCSVQuery(baseUrl + "/csv/" + csvRevId);
-
-            tags = new Dictionary<string, int>();
-            var header = true; // Skip the header.
-
-            // Split the returned string on each line.
-            foreach (var line in csv.Split(new string[] { "\r\n" }, StringSplitOptions.None))
+            if (jobResult == null)
             {
-                if (header)
-                {
-                    header = false;
-                }
-                else
-                {
-                    // Split a line in fields.
-                    var fields = line.Split(',');
-
-                    // First field is the tag enclosed in " which we remove.
-                    var tag = fields[0].Replace("\"", "");
-
-                    // Parse the count from the second field.
-                    int cnt;
-                    Int32.TryParse(fields[1].Replace("\"", ""), out cnt);
-
-                    tags.Add(tag, cnt);
-                }
+                return new Dictionary<string, int> { { "No tags found", 42 } };
             }
 
-            return tags;
+            var dict = new Dictionary<string, int>();
+            foreach (object[] row in jobResult.resultSets[0].rows)
+            {
+                int value;
+                Int32.TryParse(row[1].ToString(), out value);
+                dict.Add(row[0].ToString(), value);
+            }
+
+            return dict;
         }
         # endregion
 
@@ -163,20 +133,136 @@ namespace CVChatbot.Bot
         # region Private methods.
 
         /// <summary>
+        /// formaction is the url posted to if the query is run. This includes the revision
+        /// </summary>
+        /// <param name="data"></param>
+        /// <returns></returns>
+        private string GetFormActionUrl(string data)
+        {
+            const string formTag = @"<form id=""runQueryForm"" action=""";
+            // no fancy regex here
+            string result = null;
+            var postUrlAction = data.IndexOf(formTag);
+            if (postUrlAction > -1)
+            {
+                var closingQuote = data.IndexOf('"', postUrlAction + formTag.Length);
+                if (closingQuote > -1)
+                {
+                    result = data.Substring(postUrlAction + formTag.Length, closingQuote - (postUrlAction + formTag.Length));
+                }
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// the query result is retrieved by POSTING the formaction with no data
+        /// </summary>
+        /// <param name="url">the formaction url</param>
+        /// <returns>a jobresult</returns>
+        private JobResult GetQueryResult(string url)
+        {
+            JobResult jobResult = null;
+            using (var jobStream = PostStream(String.Format(baseUrlFormat, url), null))
+            {
+                jobResult = (JobResult)ser.ReadObject(jobStream);
+                if (jobResult.captcha)
+                {
+                    Console.WriteLine("captcha requested! not logged in?");
+                }
+                else
+                {
+                    // if a job is started on the server 
+                    // we have to poll for the result
+                    // this call might block while polling but 
+                    // if the result is already there we return immediately
+                    jobResult = GetQueryResultByPolling(jobResult);
+
+                    if (jobResult.resultSets != null
+                        && jobResult.resultSets.Length > 0)
+                    {
+                        Console.WriteLine(jobResult.resultSets[0].rows.Length);
+                    }
+                    else
+                    {
+                        Console.WriteLine("Hmm, no result sets...");
+                        // maybe an eror
+                        Console.WriteLine(jobResult.error);
+                    }
+                }
+            }
+            return jobResult;
+        }
+
+        //this call is blocking, while doing work on a timer thread
+        private JobResult GetQueryResultByPolling(JobResult jobResult)
+        {
+            // we need to poll
+            if (jobResult.running)
+            {
+                var serializeTimer = new Object();
+                var done = new ManualResetEvent(false); // wait handle
+                // we use a timer that runs every second
+                using (var timer = new Timer((state) =>
+                {
+                    // make sure we are single threaded
+                    lock (serializeTimer)
+                    {
+                        // if we are not running, don't override our result
+                        if (jobResult.running)
+                        {
+                            // poll result
+                            Console.WriteLine(jobResult.job_id);
+                            using (var pollStream = GetAsStream(String.Format(baseUrlJobFormat, jobResult.job_id)))
+                            {
+                                jobResult = (JobResult)ser.ReadObject(pollStream);
+                            }
+                        }
+                        // if we have a result, get out!
+                        if (!jobResult.running)
+                        {
+                            done.Set(); // signal main thread
+                        }
+                    }
+                }
+                    ))
+                {
+                    timer.Change(100, 1000);
+
+                    bool signaled = done.WaitOne(new TimeSpan(0, 1, 0));
+                    if (!signaled)
+                    {
+                        Console.WriteLine("no response in 1 minute");
+                    }
+                }
+            }
+            return jobResult;
+        }
+
+        /// <summary>
         /// GET from the url whatever is returned as a string.
         /// This method uses/fills the shared CookieContainer.
         /// </summary>
         private string Get(string url)
+        {
+            using (var sr = new StreamReader(GetAsStream(url)))
+            {
+                return sr.ReadToEnd();
+            }
+        }
+
+        /// <summary>
+        /// ge the raw stream from the http response
+        /// </summary>
+        /// <param name="url"></param>
+        /// <returns>the stream</returns>
+        private static Stream GetAsStream(string url)
         {
             var req = HttpWebRequest.CreateHttp(url);
             req.Method = "GET";
             req.AllowAutoRedirect = true;
             req.CookieContainer = cookies;
             var resp = (HttpWebResponse)req.GetResponse();
-            using (var sr = new StreamReader(resp.GetResponseStream()))
-            {
-                return sr.ReadToEnd();
-            }
+            return resp.GetResponseStream();
         }
 
         /// <summary>
@@ -192,22 +278,44 @@ namespace CVChatbot.Bot
         /// </summary>
         private string Post(string url, string data)
         {
+            using (var resp = PostStream(url, data))
+            {
+                using (var sr = new StreamReader(resp))
+                {
+                    return sr.ReadToEnd();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Posts and returns the stream
+        /// </summary>
+        /// <param name="url"></param>
+        /// <param name="data"></param>
+        /// <returns></returns>
+        private static Stream PostStream(string url, string data)
+        {
             var req = HttpWebRequest.CreateHttp(url);
             req.Method = "POST";
             req.CookieContainer = cookies;
-            req.ContentType = "application/x-www-form-urlencoded";
-            req.ContentLength = data.Length;
-            using (var sw = new StreamWriter(req.GetRequestStream()))
+            if (!String.IsNullOrEmpty(data))
             {
-                sw.Write(data);
-                sw.Flush();
+                req.ContentType = "application/x-www-form-urlencoded";
+                req.ContentLength = data.Length;
+                using (var sw = new StreamWriter(req.GetRequestStream()))
+                {
+                    sw.Write(data);
+                    sw.Flush();
+                }
+            }
+            else
+            {
+                req.ContentLength = 0;
             }
             var resp = (HttpWebResponse)req.GetResponse();
-            using (var sr = new StreamReader(resp.GetResponseStream()))
-            {
-                return sr.ReadToEnd();
-            }
+            return resp.GetResponseStream();
         }
+
 
 
         /// <summary>
@@ -219,10 +327,12 @@ namespace CVChatbot.Bot
         private void SEOpenIDLogin(string email, string password)
         {
             // Do a Get to retrieve the cookies.
-            var start = Get("https://openid.stackexchange.com/account/login");
+            var start = Post("http://data.stackexchange.com/user/authenticate?returnurl=/", "openid_identifier=https%3A%2F%2Fopenid.stackexchange.com%2F");
 
-            // If we find no fkey in html.
-            string fkey = CQ.Create(start).GetInputValue("fkey");
+            var html = CQ.Create(start);
+            // If we find no fkey or session in html.
+            string fkey = html.GetInputValue("fkey");
+            string session = html.GetInputValue("session");
 
             // We are already logged in.
             if (!String.IsNullOrEmpty(fkey))
@@ -230,7 +340,8 @@ namespace CVChatbot.Bot
                 // We found an fkey, use it to login via openid.
                 var data = "email=" + Uri.EscapeDataString(email) +
                            "&password=" + Uri.EscapeDataString(password) +
-                           "&fkey=" + fkey;
+                           "&fkey=" + fkey +
+                           "&session=" + session;
 
                 var res = Post("https://openid.stackexchange.com/account/login/submit", data);
 
@@ -242,5 +353,24 @@ namespace CVChatbot.Bot
         }
 
         # endregion
+
+        #region serialization classes
+
+        public class ResultSet
+        {
+            public object[] rows { get; set; }
+        }
+
+        public class JobResult
+        {
+            public string line { get; set; }
+            public string error { get; set; }
+            public bool captcha { get; set; }
+            public bool running { get; set; }
+            public string job_id { get; set; }
+            public int revisionId { get; set; }
+            public ResultSet[] resultSets { get; set; }
+        }
+        #endregion 
     }
 }

--- a/CVChatbot/CVChatbot.Bot/SedeClient.cs
+++ b/CVChatbot/CVChatbot.Bot/SedeClient.cs
@@ -7,6 +7,8 @@ using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 using System.Text.RegularExpressions;
+using System.Runtime.Serialization.Json;
+using System.Threading;
 
 namespace CVChatbot.Bot
 {
@@ -18,12 +20,18 @@ namespace CVChatbot.Bot
     {
         # region Private fields/const(s).
 
+        const string host = "http://data.stackexchange.com";
         const string baseUrl = "http://data.stackexchange.com/stackoverflow";
+        const string baseUrlFormat = "http://data.stackexchange.com{0}";
+        const string baseUrlJobFormat = "http://data.stackexchange.com/query/job/{0}";
+        const string baseUrlQueryFormat = "http://data.stackexchange.com/stackoverflow/query/{0}";
 
         /// <summary>
         /// Notice that this baby is AppDomain wide used as it is static.
         /// </summary>
         private readonly static CookieContainer cookies = new CookieContainer();
+
+        private readonly static DataContractJsonSerializer ser = new DataContractJsonSerializer(typeof(JobResult));
 
         private bool disposed;
         # endregion
@@ -68,93 +76,55 @@ namespace CVChatbot.Bot
             Dispose(true);
         }
 
+
+
         /// <summary>
         /// This runs the Sede Query and gives us the revision Id of the CSV DownloadLink
         /// </summary>
         /// <param name="baseUrl">Where sede and the query live.</param>
         /// <returns>The revision.</returns>
-        public string GetSedeQueryCsvRevisionId(string baseUrl)
+        public string GetSedeQueryRunUrl(int queryid)
         {
-            ThrowWhen.IsNullOrEmpty(baseUrl, "baseUrl");
-
-            var data = Get(baseUrl + "/query/236526/tags-that-can-be-cleared-of-votes#");
-            data = data.Remove(0, data.Length - 3000); // Footer averages around 2,500 chars, so lets say 3K just to be safe.
-
-            // This regex could be turned into a private static variable which would then allow us
-            // to instantiate it with the RegexOptions.Complied flag for even greater performance.
-            var matches = Regex.Matches(data, "(?is)\"revisionId\":\\s\\d+", RegexOptions.CultureInvariant);
-
-            if (matches.Count != 1)
-            {
-                throw new Exception("Couldn't find CSV revision ID.");
-            }
-
-            foreach (Match match in matches)
-            {
-                var matchStr = match.Value;
-                var revId = new string(matchStr.Where(Char.IsDigit).ToArray());
-                return revId;
-            }
-
-            throw new Exception("Couldn't find CSV revision ID.");
+            // get the initial query page 
+            var data = Get(String.Format(baseUrlQueryFormat, queryid));
+            return GetFormActionUrl(data);
         }
+
+
 
         /// <summary>
         /// Retrieves from the sede query the results.
         /// </summary>
         /// <returns>The tagname and the count in a dictionary.</returns>
-        public Dictionary<string, int> GetTags()
+        public Dictionary<string, int> GetTags(string url)
         {
+            ThrowWhen.IsNullOrEmpty(url, "action url");
             // Get in to run first.
-            string id = GetSedeQueryCsvRevisionId(baseUrl);
+            var jobResult = GetQueryResult(url);
 
-            return GetTags(id);
+            return GetTags(jobResult);
         }
 
         /// <summary>
         /// Retrieves from the sede query the results.
         /// </summary>
         /// <returns>The tagname and the count in a dictionary.</returns>
-        public Dictionary<string, int> GetTags(string csvRevId)
+        public Dictionary<string, int> GetTags(JobResult jobResult)
         {
-            ThrowWhen.IsNullOrEmpty(csvRevId, "csvRevId");
-
-            // For collecting the result.
-            Dictionary<string, int> tags = null;
-
-            // This gets a text/csv content
-            // tag, count
-            // "java", "200"
-            // "php", "120"
-            var csv = GetCSVQuery(baseUrl + "/csv/" + csvRevId);
-
-            tags = new Dictionary<string, int>();
-            var header = true; // Skip the header.
-
-            // Split the returned string on each line.
-            foreach (var line in csv.Split(new string[] { "\r\n" }, StringSplitOptions.None))
+            if (jobResult == null)
             {
-                if (header)
-                {
-                    header = false;
-                }
-                else
-                {
-                    // Split a line in fields.
-                    var fields = line.Split(',');
-
-                    // First field is the tag enclosed in " which we remove.
-                    var tag = fields[0].Replace("\"", "");
-
-                    // Parse the count from the second field.
-                    int cnt;
-                    Int32.TryParse(fields[1].Replace("\"", ""), out cnt);
-
-                    tags.Add(tag, cnt);
-                }
+                return new Dictionary<string, int> { { "No tags found", 42 } };
             }
 
-            return tags;
+            var dict = new Dictionary<string, int>();
+            foreach (object[] row in jobResult.resultSets[0].rows)
+            {
+                int value;
+                Int32.TryParse(row[1].ToString(), out value);
+                dict.Add(row[0].ToString(), value);
+            }
+
+            return dict;
         }
         # endregion
 
@@ -163,20 +133,136 @@ namespace CVChatbot.Bot
         # region Private methods.
 
         /// <summary>
+        /// formaction is the url posted to if the query is run. This includes the revision
+        /// </summary>
+        /// <param name="data"></param>
+        /// <returns></returns>
+        private string GetFormActionUrl(string data)
+        {
+            const string formTag = @"<form id=""runQueryForm"" action=""";
+            // no fancy regex here
+            string result = null;
+            var postUrlAction = data.IndexOf(formTag);
+            if (postUrlAction > -1)
+            {
+                var closingQuote = data.IndexOf('"', postUrlAction + formTag.Length);
+                if (closingQuote > -1)
+                {
+                    result = data.Substring(postUrlAction + formTag.Length, closingQuote - (postUrlAction + formTag.Length));
+                }
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// the query result is retrieved by POSTING the formaction with no data
+        /// </summary>
+        /// <param name="url">the formaction url</param>
+        /// <returns>a jobresult</returns>
+        private JobResult GetQueryResult(string url)
+        {
+            JobResult jobResult = null;
+            using (var jobStream = PostStream(String.Format(baseUrlFormat, url), null))
+            {
+                jobResult = (JobResult)ser.ReadObject(jobStream);
+                if (jobResult.captcha)
+                {
+                    Console.WriteLine("captcha requested! not logged in?");
+                }
+                else
+                {
+                    // if a job is started on the server 
+                    // we have to poll for the result
+                    // this call might block while polling but 
+                    // if the result is already there we return immediately
+                    jobResult = GetQueryResultByPolling(jobResult);
+
+                    if (jobResult.resultSets != null
+                        && jobResult.resultSets.Length > 0)
+                    {
+                        Console.WriteLine(jobResult.resultSets[0].rows.Length);
+                    }
+                    else
+                    {
+                        Console.WriteLine("Hmm, no result sets...");
+                        // maybe an eror
+                        Console.WriteLine(jobResult.error);
+                    }
+                }
+            }
+            return jobResult;
+        }
+
+        //this call is blocking, while doing work on a timer thread
+        private JobResult GetQueryResultByPolling(JobResult jobResult)
+        {
+            // we need to poll
+            if (jobResult.running)
+            {
+                var serializeTimer = new Object();
+                var done = new ManualResetEvent(false); // wait handle
+                // we use a timer that runs every second
+                using (var timer = new Timer((state) =>
+                {
+                    // make sure we are single threaded
+                    lock (serializeTimer)
+                    {
+                        // if we are not running, don't override our result
+                        if (jobResult.running)
+                        {
+                            // poll result
+                            Console.WriteLine(jobResult.job_id);
+                            using (var pollStream = GetAsStream(String.Format(baseUrlJobFormat, jobResult.job_id)))
+                            {
+                                jobResult = (JobResult)ser.ReadObject(pollStream);
+                            }
+                        }
+                        // if we have a result, get out!
+                        if (!jobResult.running)
+                        {
+                            done.Set(); // signal main thread
+                        }
+                    }
+                }
+                    ))
+                {
+                    timer.Change(100, 1000);
+
+                    bool signaled = done.WaitOne(new TimeSpan(0, 1, 0));
+                    if (!signaled)
+                    {
+                        Console.WriteLine("no response in 1 minute");
+                    }
+                }
+            }
+            return jobResult;
+        }
+
+        /// <summary>
         /// GET from the url whatever is returned as a string.
         /// This method uses/fills the shared CookieContainer.
         /// </summary>
         private string Get(string url)
+        {
+            using (var sr = new StreamReader(GetAsStream(url)))
+            {
+                return sr.ReadToEnd();
+            }
+        }
+
+        /// <summary>
+        /// ge the raw stream from the http response
+        /// </summary>
+        /// <param name="url"></param>
+        /// <returns>the stream</returns>
+        private static Stream GetAsStream(string url)
         {
             var req = HttpWebRequest.CreateHttp(url);
             req.Method = "GET";
             req.AllowAutoRedirect = true;
             req.CookieContainer = cookies;
             var resp = (HttpWebResponse)req.GetResponse();
-            using (var sr = new StreamReader(resp.GetResponseStream()))
-            {
-                return sr.ReadToEnd();
-            }
+            return resp.GetResponseStream();
         }
 
         /// <summary>
@@ -192,22 +278,44 @@ namespace CVChatbot.Bot
         /// </summary>
         private string Post(string url, string data)
         {
+            using (var resp = PostStream(url, data))
+            {
+                using (var sr = new StreamReader(resp))
+                {
+                    return sr.ReadToEnd();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Posts and returns the stream
+        /// </summary>
+        /// <param name="url"></param>
+        /// <param name="data"></param>
+        /// <returns></returns>
+        private static Stream PostStream(string url, string data)
+        {
             var req = HttpWebRequest.CreateHttp(url);
             req.Method = "POST";
             req.CookieContainer = cookies;
-            req.ContentType = "application/x-www-form-urlencoded";
-            req.ContentLength = data.Length;
-            using (var sw = new StreamWriter(req.GetRequestStream()))
+            if (!String.IsNullOrEmpty(data))
             {
-                sw.Write(data);
-                sw.Flush();
+                req.ContentType = "application/x-www-form-urlencoded";
+                req.ContentLength = data.Length;
+                using (var sw = new StreamWriter(req.GetRequestStream()))
+                {
+                    sw.Write(data);
+                    sw.Flush();
+                }
+            }
+            else
+            {
+                req.ContentLength = 0;
             }
             var resp = (HttpWebResponse)req.GetResponse();
-            using (var sr = new StreamReader(resp.GetResponseStream()))
-            {
-                return sr.ReadToEnd();
-            }
+            return resp.GetResponseStream();
         }
+
 
 
         /// <summary>
@@ -219,10 +327,12 @@ namespace CVChatbot.Bot
         private void SEOpenIDLogin(string email, string password)
         {
             // Do a Get to retrieve the cookies.
-            var start = Get("https://openid.stackexchange.com/account/login");
+            var start = Post("http://data.stackexchange.com/user/authenticate?returnurl=/", "openid_identifier=https%3A%2F%2Fopenid.stackexchange.com%2F");
 
-            // If we find no fkey in html.
-            string fkey = CQ.Create(start).GetInputValue("fkey");
+            var html = CQ.Create(start);
+            // If we find no fkey or session in html.
+            string fkey = html.GetInputValue("fkey");
+            string session = html.GetInputValue("session");
 
             // We are already logged in.
             if (!String.IsNullOrEmpty(fkey))
@@ -230,7 +340,8 @@ namespace CVChatbot.Bot
                 // We found an fkey, use it to login via openid.
                 var data = "email=" + Uri.EscapeDataString(email) +
                            "&password=" + Uri.EscapeDataString(password) +
-                           "&fkey=" + fkey;
+                           "&fkey=" + fkey +
+                           "&session=" + session;
 
                 var res = Post("https://openid.stackexchange.com/account/login/submit", data);
 
@@ -242,5 +353,24 @@ namespace CVChatbot.Bot
         }
 
         # endregion
+
+        #region serialization classes
+
+        public class ResultSet
+        {
+            public object[] rows { get; set; }
+        }
+
+        public class JobResult
+        {
+            public string line { get; set; }
+            public string error { get; set; }
+            public bool captcha { get; set; }
+            public bool running { get; set; }
+            public string job_id { get; set; }
+            public int revisionId { get; set; }
+            public ResultSet[] resultSets { get; set; }
+        }
+        #endregion
     }
 }


### PR DESCRIPTION
fixed the bug when the query was not in the SEDE server cache which didn't have a revisonid in that case. This is a rewrite of the whole fetching stuff and more closely mimicking what the webclient actually does. As a plus we can use a Json de-serializer because all results are now coming from an ajax end-point,