### PR TITLE
Trigger regex updates

### DIFF
--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/Triggers/OutOfCloseVotes.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/Triggers/OutOfCloseVotes.cs
@@ -30,7 +30,7 @@ namespace CVChatbot.Bot.ChatbotActions.Triggers
 
         protected override string GetRegexMatchingPattern()
         {
-            return @"^(?:> +)?you have no more close votes today; come back in (\d+) hours\.$";
+            return @"^(?:> +)?you have no more close votes today; come back in (\d+) hours\.?$";
         }
 
         public override string GetActionName()

--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/Triggers/OutOfReviewActions.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/Triggers/OutOfReviewActions.cs
@@ -39,7 +39,7 @@ namespace CVChatbot.Bot.ChatbotActions.Triggers
 
         protected override string GetRegexMatchingPattern()
         {
-            return @"^(?:> +)?thank you for reviewing (\d+) close votes today; come back in ([\w ]+) to continue reviewing\.$";
+            return @"^(?:> +)?thank you for reviewing (\d+) close votes today; come back in ([\w ]+) to continue reviewing\.?$";
         }
 
         public override string GetActionName()


### PR DESCRIPTION
Sometimes a user forgets to include the ending period in a message, so I've made it optionable in a couple trigger regexes.