### PR TITLE
C# 6 features/clean up

### DIFF
--- a/CVChatbot/CVChatbot.Bot/ChatMessageProcessor.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatMessageProcessor.cs
@@ -90,7 +90,7 @@ namespace CVChatbot.Bot
         /// <returns></returns>
         private bool DoesUserHavePermissionToRunAction(ChatbotAction actionToRun, int chatUserId)
         {
-            var neededPermissionLevel = actionToRun.GetPermissionLevel();
+            var neededPermissionLevel = actionToRun.PermissionLevel;
 
             // If the permission level of the action is "everyone" then just return true.
             // Don't need to do anything else, like searching though the database.
@@ -146,7 +146,7 @@ namespace CVChatbot.Bot
         {
             // Record as started.
             var id = RunningChatbotActionsManager.MarkChatbotActionAsStarted(
-                action.GetActionName(),
+                action.ActionName,
                 incommingChatMessage.Author.Name,
                 incommingChatMessage.Author.ID);
 
@@ -178,10 +178,8 @@ namespace CVChatbot.Bot
         /// a table of commands that the chatbot did not recognize.
         /// </summary>
         /// <param name="command"></param>
-        private void SendUnrecognizedCommandToDatabase(string command)
-        {
+        private void SendUnrecognizedCommandToDatabase(string command) =>
             da.InsertUnrecognizedCommand(command);
-        }
 
         /// <summary>
         /// Call this method if you get an error while running a ChatbotAction.
@@ -192,8 +190,7 @@ namespace CVChatbot.Bot
         /// <param name="actionToRun"></param>
         private void TellChatAboutErrorWhileRunningAction(Exception ex, Room chatRoom, ChatbotAction actionToRun)
         {
-            var headerLine = "I hit an error while trying to run '{0}':"
-                .FormatSafely(actionToRun.GetActionName());
+            var headerLine = $"I hit an error while trying to run '{actionToRun.ActionName}':";
 
             var errorMessage = "    " + ex.FullErrorMessage(Environment.NewLine + "    ");
 

--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/ChatbotAction.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/ChatbotAction.cs
@@ -1,10 +1,5 @@
 ﻿using ChatExchangeDotNet;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace CVChatbot.Bot.ChatbotActions
 {
@@ -13,6 +8,8 @@ namespace CVChatbot.Bot.ChatbotActions
     /// </summary>
     public abstract class ChatbotAction
     {
+        public static RegexOptions RegexObjOptions => RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase;
+
         /// <summary>
         /// Determines if the incoming chat message activates this action.
         /// </summary>
@@ -22,16 +19,13 @@ namespace CVChatbot.Bot.ChatbotActions
         public bool DoesChatMessageActiveAction(Message incomingMessage, bool isMessageAReplyToChatbot)
         {
             // First, check if the message is a reply or not and if the Action accepts that.
-            var requiredIsReplyValue = GetMessageIsReplyToChatbotRequiredValue();
-
-            if (isMessageAReplyToChatbot != requiredIsReplyValue)
+            if (isMessageAReplyToChatbot != ReplyMessagesOnly)
                 return false;
 
             // Now regex test it.
             var formattedContents = GetMessageContentsReadyForRegexParsing(incomingMessage);
-            var regex = GetRegexMatchingObject();
 
-            return regex.IsMatch(formattedContents);
+            return RegexMatchingObject.IsMatch(formattedContents);
         }
 
         /// <summary>
@@ -40,25 +34,14 @@ namespace CVChatbot.Bot.ChatbotActions
         /// action to be activated. For example, User Commands MUST be a reply to the chatbot.
         /// </summary>
         /// <returns></returns>
-        protected abstract bool GetMessageIsReplyToChatbotRequiredValue();
+        protected abstract bool ReplyMessagesOnly { get; }
 
         /// <summary>
-        /// Returns the regex matching pattern for this action. This is used to determine if the
+        /// Returns the regex matching object for this action. This is used to determine if the
         /// chat message is appropriate for this action.
         /// </summary>
-        /// <returns></returns>
-        protected abstract string GetRegexMatchingPattern();
-
-        /// <summary>
-        /// This is already populated with the necessary matching pattern text.
-        /// You may call this method from the RunAction() method if you need arguments within chat message.
-        /// </summary>
         /// <returns>The regex object needed for pattern matching with the incoming chat message.</returns>
-        protected Regex GetRegexMatchingObject()
-        {
-            var pattern = GetRegexMatchingPattern();
-            return new Regex(pattern, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
-        }
+        protected abstract Regex RegexMatchingObject { get; }
 
         /// <summary>
         /// Formats the incoming message's contents so that it can be regex matched more reliably.
@@ -78,25 +61,25 @@ namespace CVChatbot.Bot.ChatbotActions
         /// Returns the human-friendly name of the chatbot action.
         /// </summary>
         /// <returns></returns>
-        public abstract string GetActionName();
+        public abstract string ActionName { get; }
 
         /// <summary>
         /// Returns a short description of what the action does. Triggers return null.
         /// </summary>
         /// <returns></returns>
-        public abstract string GetActionDescription();
+        public abstract string ActionDescription { get; }
 
         /// <summary>
         /// Returns the usage of the action, including optional arguments. Triggers return null.
         /// </summary>
         /// <returns></returns>
-        public abstract string GetActionUsage();
+        public abstract string ActionUsage { get; }
 
         /// <summary>
         /// Returns the minimum permission level needed by a user to run this action.
         /// </summary>
         /// <returns></returns>
-        public abstract ActionPermissionLevel GetPermissionLevel();
+        public abstract ActionPermissionLevel PermissionLevel { get; }
     }
 
     /// <summary>

--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/ChatbotActionRegister.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/ChatbotActionRegister.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace CVChatbot.Bot.ChatbotActions
 {
@@ -37,7 +35,7 @@ namespace CVChatbot.Bot.ChatbotActions
         {
             return AllChatActions
                 .Single(x => x is TAction)
-                .GetActionUsage();
+                .ActionUsage;
         }
 
         private static class ReflectiveEnumerator

--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/Alive.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/Alive.cs
@@ -1,14 +1,25 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using TCL.Extensions;
 
 namespace CVChatbot.Bot.ChatbotActions.Commands
 {
     public class Alive : UserCommand
     {
+        private Regex ptn = new Regex(@"^(?:(?:are )?you )?(alive|still there|(still )?with us)\??$", RegexObjOptions);
+
+        public override string ActionDescription => "A simple ping command to test if the bot is running.";
+
+        public override string ActionName => "Alive";
+
+        public override string ActionUsage => "alive";
+
+        public override ActionPermissionLevel PermissionLevel => ActionPermissionLevel.Everyone;
+
+        protected override Regex RegexMatchingObject => ptn;
+
+
+
         public override void RunAction(ChatExchangeDotNet.Message incommingChatMessage, ChatExchangeDotNet.Room chatRoom, InstallationSettings roomSettings)
         {
             var responsePhrases = new List<string>()
@@ -25,31 +36,6 @@ namespace CVChatbot.Bot.ChatbotActions.Commands
             var phrase = responsePhrases.PickRandom();
 
             chatRoom.PostReplyOrThrow(incommingChatMessage, phrase);
-        }
-
-        public override ActionPermissionLevel GetPermissionLevel()
-        {
-            return ActionPermissionLevel.Everyone;
-        }
-
-        protected override string GetRegexMatchingPattern()
-        {
-            return @"^(?:(?:are )?you )?(alive|still there|(still )?with us)\??$";
-        }
-
-        public override string GetActionName()
-        {
-            return "Alive";
-        }
-
-        public override string GetActionDescription()
-        {
-            return "A simple ping command to test if the bot is running.";
-        }
-
-        public override string GetActionUsage()
-        {
-            return "alive";
         }
     }
 }

--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/AuditStats.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/AuditStats.cs
@@ -1,17 +1,26 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using TCL.Extensions;
 using System.Text.RegularExpressions;
-using System.Threading;
 using CVChatbot.Bot.Database;
 
 namespace CVChatbot.Bot.ChatbotActions.Commands
 {
     public class AuditStats : UserCommand
     {
+        private readonly Regex ptn = new Regex("^(show (me )?|display )?(my )?(audit stats|stats (of|about) my audits)( pl(ease|[sz]))?$", RegexObjOptions);
+
+        public override string ActionDescription => "Shows stats about your recorded audits.";
+
+        public override string ActionName => "Audit Stats";
+
+        public override string ActionUsage => "audit stats";
+
+        public override ActionPermissionLevel PermissionLevel => ActionPermissionLevel.Registered;
+
+        protected override Regex RegexMatchingObject => ptn;
+
+
+
         public override void RunAction(ChatExchangeDotNet.Message incommingChatMessage, ChatExchangeDotNet.Room chatRoom, InstallationSettings roomSettings)
         {
             var da = new DatabaseAccessor(roomSettings.DatabaseConnectionString);
@@ -26,37 +35,12 @@ namespace CVChatbot.Bot.ChatbotActions.Commands
 
             var message = auditEntries
                 .ToStringTable(new[] { "Tag Name", "%", "Count" },
-                    (x) => x.TagName,
-                    (x) => Math.Round(x.Percent, 2),
-                    (x) => x.Count);
+                    x => x.TagName,
+                    x => Math.Round(x.Percent, 2),
+                    x => x.Count);
 
             chatRoom.PostReplyOrThrow(incommingChatMessage, "Stats of all tracked audits by tag:");
             chatRoom.PostMessageOrThrow(message);
-        }
-
-        public override ActionPermissionLevel GetPermissionLevel()
-        {
-            return ActionPermissionLevel.Registered;
-        }
-
-        protected override string GetRegexMatchingPattern()
-        {
-            return @"^(show (me )?|display )?(my )?(audit stats|stats (of|about) my audits)( pl(ease|[sz]))?$";
-        }
-
-        public override string GetActionName()
-        {
-            return "Audit Stats";
-        }
-
-        public override string GetActionDescription()
-        {
-            return "Shows stats about your recorded audits.";
-        }
-
-        public override string GetActionUsage()
-        {
-            return "audit stats";
         }
     }
 }

--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/CurrentSession.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/CurrentSession.cs
@@ -1,16 +1,27 @@
 ﻿using CVChatbot.Bot.Database;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using TCL.Extensions;
+using System.Text.RegularExpressions;
 
 namespace CVChatbot.Bot.ChatbotActions.Commands
 {
     public class CurrentSession : UserCommand
     {
+        private Regex ptn = new Regex(@"^(do i have an? |what is my )?(current|active|review)( review)? session( going( on)?)?\??$", RegexObjOptions);
+
+        public override string ActionDescription =>
+            "Tells if the user has an open session or not, and when it started.";
+
+        public override string ActionName => "Current Session";
+
+        public override string ActionUsage => "current session";
+
+        public override ActionPermissionLevel PermissionLevel => ActionPermissionLevel.Registered;
+
+        protected override Regex RegexMatchingObject => ptn;
+
+
+
         public override void RunAction(ChatExchangeDotNet.Message incommingChatMessage, ChatExchangeDotNet.Room chatRoom, InstallationSettings roomSettings)
         {
             var da = new DatabaseAccessor(roomSettings.DatabaseConnectionString);
@@ -30,31 +41,6 @@ namespace CVChatbot.Bot.ChatbotActions.Commands
 
                 chatRoom.PostReplyOrThrow(incommingChatMessage, message);
             }
-        }
-
-        public override ActionPermissionLevel GetPermissionLevel()
-        {
-            return ActionPermissionLevel.Registered;
-        }
-
-        protected override string GetRegexMatchingPattern()
-        {
-            return @"^(do i have an? |what is my )?(current|active|review)( review)? session( going( on)?)?\??$";
-        }
-
-        public override string GetActionName()
-        {
-            return "Current Session";
-        }
-
-        public override string GetActionDescription()
-        {
-            return "Tells if the user has an open session or not, and when it started.";
-        }
-
-        public override string GetActionUsage()
-        {
-            return "current session";
         }
     }
 }

--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/CurrentTag.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/CurrentTag.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using TCL.Extensions;
+﻿using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace CVChatbot.Bot.ChatbotActions.Commands
 {
@@ -13,25 +8,20 @@ namespace CVChatbot.Bot.ChatbotActions.Commands
     /// </summary>
     public class CurrentTag : UserCommand
     {
-        public override string GetActionDescription()
-        {
-            return "Get the tag that has the most amount of manageable close queue items from the SEDE query.";
-        }
+        private Regex ptn = new Regex(@"^(what is the )?current tag( pl(ease|[sz]))?\??$", RegexObjOptions);
 
-        public override string GetActionName()
-        {
-            return "Current Tag";
-        }
+        public override string ActionDescription =>
+            "Get the tag that has the most amount of manageable close queue items from the SEDE query.";
 
-        public override string GetActionUsage()
-        {
-            return "current tag";
-        }
+        public override string ActionName => "Current Tag";
 
-        public override ActionPermissionLevel GetPermissionLevel()
-        {
-            return ActionPermissionLevel.Registered;
-        }
+        public override string ActionUsage => "current tag";
+
+        public override ActionPermissionLevel PermissionLevel => ActionPermissionLevel.Registered;
+
+        protected override Regex RegexMatchingObject => ptn;
+
+
 
         /// <summary>
         /// Outputs the tag.
@@ -51,7 +41,7 @@ namespace CVChatbot.Bot.ChatbotActions.Commands
             string dataMessage;
             if (tags != null)
             {
-                dataMessage = "The current tag is [tag:{0}] with {1} known review items.".FormatInline(tags.First().Key, tags.First().Value);
+                dataMessage = $"The current tag is [tag:{tags.First().Key}] with {tags.First().Value} known review items.";
             }
             else
             {
@@ -59,11 +49,6 @@ namespace CVChatbot.Bot.ChatbotActions.Commands
             }
 
             chatRoom.PostReplyOrThrow(incommingChatMessage, dataMessage);
-        }
-
-        protected override string GetRegexMatchingPattern()
-        {
-            return @"^(what is the )?current tag( pl(ease|[sz]))?\??$";
         }
     }
 }

--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/EndSession.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/EndSession.cs
@@ -1,15 +1,27 @@
 ﻿using CVChatbot.Bot.Database;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using TCL.Extensions;
+using System.Text.RegularExpressions;
 
 namespace CVChatbot.Bot.ChatbotActions.Commands
 {
     public class EndSession : UserCommand
     {
+        private Regex ptn = new Regex(@"^(end|done( with)?) (my )?(session|review(s|ing))( pl(ease|[sz]))?$", RegexObjOptions);
+
+        public override string ActionDescription =>
+            "If a user has an open review session this command will force end that session.";
+
+        public override string ActionName => "End Session";
+
+        public override string ActionUsage => "end session";
+
+        public override ActionPermissionLevel PermissionLevel => ActionPermissionLevel.Registered;
+
+        protected override Regex RegexMatchingObject => ptn;
+
+
+
         public override void RunAction(ChatExchangeDotNet.Message incommingChatMessage, ChatExchangeDotNet.Room chatRoom, InstallationSettings roomSettings)
         {
             var da = new DatabaseAccessor(roomSettings.DatabaseConnectionString);
@@ -38,32 +50,6 @@ namespace CVChatbot.Bot.ChatbotActions.Commands
                 .FormatInline(ChatbotActionRegister.GetChatBotActionUsage<LastSessionStats>()) +
                 "In addition, the number of review items is most likely not set, use the command `{0}` to fix that."
                 .FormatInline(ChatbotActionRegister.GetChatBotActionUsage<LastSessionEditCount>()));
-
-        }
-
-        public override ActionPermissionLevel GetPermissionLevel()
-        {
-            return ActionPermissionLevel.Registered;
-        }
-
-        protected override string GetRegexMatchingPattern()
-        {
-            return @"^(end|done( with)?) (my )?(session|review(s|ing))( pl(ease|[sz]))?$";
-        }
-
-        public override string GetActionName()
-        {
-            return "End Session";
-        }
-
-        public override string GetActionDescription()
-        {
-            return "If a user has an open review session this command will force end that session.";
-        }
-
-        public override string GetActionUsage()
-        {
-            return "end session";
         }
     }
 }

--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/Help.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/Help.cs
@@ -1,15 +1,25 @@
-﻿using ChatExchangeDotNet;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Text.RegularExpressions;
+using ChatExchangeDotNet;
 using TCL.Extensions;
 
 namespace CVChatbot.Bot.ChatbotActions.Commands
 {
     public class Help : UserCommand
     {
+        private Regex ptn = new Regex("^(i need )?(help|assistance|halp|an adult)( me)?( (please|pl[sz]))?$", RegexObjOptions);
+
+        public override string ActionDescription => "Prints info about this software.";
+
+        public override string ActionName => "Help";
+
+        public override string ActionUsage => "help";
+
+        public override ActionPermissionLevel PermissionLevel => ActionPermissionLevel.Everyone;
+
+        protected override Regex RegexMatchingObject => ptn;
+
+
+
         public override void RunAction(Message incommingChatMessage, Room chatRoom, InstallationSettings roomSettings)
         {
             var message = "This is a chat bot for the SO Close Vote Reviewers chat room, developed by [gunr2171](http://stackoverflow.com/users/1043380/gunr2171) and the other members of the SO Close Vote Reviewers chat room. " +
@@ -17,31 +27,6 @@ namespace CVChatbot.Bot.ChatbotActions.Commands
                 "Reply with `{0}` to see a list of commands."
                     .FormatInline(ChatbotActionRegister.GetChatBotActionUsage<Commands>());
             chatRoom.PostMessageOrThrow(message);
-        }
-
-        public override ActionPermissionLevel GetPermissionLevel()
-        {
-            return ActionPermissionLevel.Everyone;
-        }
-
-        protected override string GetRegexMatchingPattern()
-        {
-            return "^(i need )?(help|assistance|halp|an adult)( me)?( (please|pl[sz]))?$";
-        }
-
-        public override string GetActionName()
-        {
-            return "Help";
-        }
-
-        public override string GetActionDescription()
-        {
-            return "Prints info about this software.";
-        }
-
-        public override string GetActionUsage()
-        {
-            return "help";
         }
     }
 }

--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/LastSessionEditCount.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/LastSessionEditCount.cs
@@ -1,10 +1,5 @@
-﻿using CVChatbot.Bot.Database;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
+﻿using System.Text.RegularExpressions;
+using CVChatbot.Bot.Database;
 using TCL.Extensions;
 
 namespace CVChatbot.Bot.ChatbotActions.Commands
@@ -14,6 +9,21 @@ namespace CVChatbot.Bot.ChatbotActions.Commands
     /// </summary>
     public class LastSessionEditCount : UserCommand
     {
+        private Regex ptn = new Regex(@"^last session edit count (\d+)$", RegexObjOptions);
+
+        public override string ActionDescription =>
+            "Edits the number of reviewed items in your last review session.";
+
+        public override string ActionName => "Last Session Edit Count";
+
+        public override string ActionUsage => "last session edit count <new count>";
+
+        public override ActionPermissionLevel PermissionLevel => ActionPermissionLevel.Registered;
+
+        protected override Regex RegexMatchingObject => ptn;
+
+
+
         public override void RunAction(ChatExchangeDotNet.Message incommingChatMessage, ChatExchangeDotNet.Room chatRoom, InstallationSettings roomSettings)
         {
             var da = new DatabaseAccessor(roomSettings.DatabaseConnectionString);
@@ -25,7 +35,7 @@ namespace CVChatbot.Bot.ChatbotActions.Commands
                 return;
             }
 
-            var newReviewCount = GetRegexMatchingObject()
+            var newReviewCount = RegexMatchingObject
                 .Match(GetMessageContentsReadyForRegexParsing(incommingChatMessage))
                 .Groups[1]
                 .Value
@@ -59,31 +69,6 @@ namespace CVChatbot.Bot.ChatbotActions.Commands
             da.EditLatestCompletedSessionItemsReviewedCount(lastSession.Id, newReviewCount);
 
             chatRoom.PostReplyOrThrow(incommingChatMessage, replyMessage);
-        }
-
-        public override ActionPermissionLevel GetPermissionLevel()
-        {
-            return ActionPermissionLevel.Registered;
-        }
-
-        protected override string GetRegexMatchingPattern()
-        {
-            return @"^last session edit count (\d+)$";
-        }
-
-        public override string GetActionName()
-        {
-            return "Last Session Edit Count";
-        }
-
-        public override string GetActionDescription()
-        {
-            return "Edits the number of reviewed items in your last review session.";
-        }
-
-        public override string GetActionUsage()
-        {
-            return "last session edit count <new count>";
         }
     }
 }

--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/LastSessionStats.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/LastSessionStats.cs
@@ -1,11 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using TCL.Extensions;
 using CVChatbot.Bot.Database;
+using System.Text.RegularExpressions;
 
 namespace CVChatbot.Bot.ChatbotActions.Commands
 {
@@ -14,6 +10,20 @@ namespace CVChatbot.Bot.ChatbotActions.Commands
     /// </summary>
     public class LastSessionStats : UserCommand
     {
+        private Regex ptn = new Regex("^last session stats$", RegexObjOptions);
+
+        public override string ActionDescription => "Shows stats about your last review session.";
+
+        public override string ActionName => "Lass Session Stats";
+
+        public override string ActionUsage => "last session stats";
+
+        public override ActionPermissionLevel PermissionLevel => ActionPermissionLevel.Registered;
+
+        protected override Regex RegexMatchingObject => ptn;
+
+
+
         public override void RunAction(ChatExchangeDotNet.Message incommingChatMessage, ChatExchangeDotNet.Room chatRoom, InstallationSettings roomSettings)
         {
             var da = new DatabaseAccessor(roomSettings.DatabaseConnectionString);
@@ -68,31 +78,6 @@ namespace CVChatbot.Bot.ChatbotActions.Commands
             }
 
             chatRoom.PostReplyOrThrow(incommingChatMessage, statMessage);
-        }
-
-        public override ActionPermissionLevel GetPermissionLevel()
-        {
-            return ActionPermissionLevel.Registered;
-        }
-
-        protected override string GetRegexMatchingPattern()
-        {
-            return @"^last session stats$";
-        }
-
-        public override string GetActionName()
-        {
-            return "Lass Session Stats";
-        }
-
-        public override string GetActionDescription()
-        {
-            return "Shows stats about your last review session.";
-        }
-
-        public override string GetActionUsage()
-        {
-            return "last session stats";
         }
     }
 }

--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/MyCompletedTags.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/MyCompletedTags.cs
@@ -1,18 +1,24 @@
 ﻿using CVChatbot.Bot.Database;
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Text.RegularExpressions;
 
 namespace CVChatbot.Bot.ChatbotActions.Commands
 {
     public class MyCompletedTags : UserCommand
     {
-        protected override string GetRegexMatchingPattern()
-        {
-            return @"^my completed tags$";
-        }
+        private Regex ptn = new Regex("^my completed tags$", RegexObjOptions);
+
+        public override string ActionDescription => "Returns a list of tags you have completed.";
+
+        public override string ActionName => "My Completed Tags";
+
+        public override string ActionUsage => "my completed tags";
+
+        protected override Regex RegexMatchingObject => ptn;
+
+        public override ActionPermissionLevel PermissionLevel => ActionPermissionLevel.Registered;
+
+
 
         public override void RunAction(ChatExchangeDotNet.Message incommingChatMessage, ChatExchangeDotNet.Room chatRoom, InstallationSettings roomSettings)
         {
@@ -34,26 +40,6 @@ namespace CVChatbot.Bot.ChatbotActions.Commands
 
             chatRoom.PostReplyOrThrow(incommingChatMessage, headerMessage);
             chatRoom.PostMessageOrThrow(dataMessage);
-        }
-
-        public override string GetActionName()
-        {
-            return "My Completed Tags";
-        }
-
-        public override string GetActionDescription()
-        {
-            return "Returns a list of tags you have completed.";
-        }
-
-        public override string GetActionUsage()
-        {
-            return "my completed tags";
-        }
-
-        public override ActionPermissionLevel GetPermissionLevel()
-        {
-            return ActionPermissionLevel.Registered;
         }
     }
 }

--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/NextTags.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/NextTags.cs
@@ -1,38 +1,30 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Text.RegularExpressions;
 using TCL.Extensions;
 
 namespace CVChatbot.Bot.ChatbotActions.Commands
 {
     public class NextTags : UserCommand
     {
-        public override string GetActionDescription()
-        {
-            return "Displays the first X tags from the SEDE query to focus on.";
-        }
+        private Regex ptn = new Regex(@"^next(?: (\d+))? tags$", RegexObjOptions);
 
-        public override string GetActionName()
-        {
-            return "Next Tags";
-        }
+        public override string ActionDescription =>
+            "Displays the first X tags from the SEDE query to focus on.";
 
-        public override string GetActionUsage()
-        {
-            return "next [#] tags";
-        }
+        public override string ActionName => "Next Tags";
 
-        public override ActionPermissionLevel GetPermissionLevel()
-        {
-            return ActionPermissionLevel.Registered;
-        }
+        public override string ActionUsage => "next [#] tags";
+
+        public override ActionPermissionLevel PermissionLevel => ActionPermissionLevel.Registered;
+
+        protected override Regex RegexMatchingObject => ptn;
+
+
 
         public override void RunAction(ChatExchangeDotNet.Message incommingChatMessage, ChatExchangeDotNet.Room chatRoom, InstallationSettings roomSettings)
         {
             // First, get the number in the command
-            var tagsToFetchArgument = GetRegexMatchingObject()
+            var tagsToFetchArgument = RegexMatchingObject
                 .Match(GetMessageContentsReadyForRegexParsing(incommingChatMessage))
                 .Groups[1]
                 .Value
@@ -73,16 +65,11 @@ namespace CVChatbot.Bot.ChatbotActions.Commands
 
             var tagString = tags
                 .Take(tagsToFetch)
-                .Select(x => "[tag:{0}] `{1}`".FormatInline(x.Key, x.Value))
+                .Select(x => $"[tag:{x.Key}] `{x.Value}`")
                 .ToCSV(", ");
 
-            var message = "The next {0} tags are: {1}".FormatInline(tagsToFetch, tagString);
+            var message = $"The next {tagsToFetch} tags are: {tagString}";
             chatRoom.PostReplyOrThrow(incommingChatMessage, message);
-        }
-
-        protected override string GetRegexMatchingPattern()
-        {
-            return @"^next(?: (\d+))? tags$";
         }
     }
 }

--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/PingReviewers.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/PingReviewers.cs
@@ -1,19 +1,26 @@
 ﻿using CVChatbot.Bot.Database;
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using TCL.Extensions;
+using System.Text.RegularExpressions;
 
 namespace CVChatbot.Bot.ChatbotActions.Commands
 {
     public class PingReviewers : UserCommand
     {
-        protected override string GetRegexMatchingPattern()
-        {
-            return @"^ping reviewers (.+)$";
-        }
+        private Regex ptn = new Regex("^ping reviewers (.+)$");
+
+        public override string ActionDescription =>
+            "The bot will send a message with an @reply to all users that have done reviews recently.";
+
+        public override string ActionName => "Ping Reviewers";
+
+        public override string ActionUsage => "ping reviewers <message>";
+
+        public override ActionPermissionLevel PermissionLevel => ActionPermissionLevel.Owner;
+
+        protected override Regex RegexMatchingObject => ptn;
+
+
 
         public override void RunAction(ChatExchangeDotNet.Message incommingChatMessage, ChatExchangeDotNet.Room chatRoom, InstallationSettings roomSettings)
         {
@@ -34,33 +41,13 @@ namespace CVChatbot.Bot.ChatbotActions.Commands
 
             var combinedUserNames = userNames.ToCSV(" ");
 
-            var messageFromIncommingChatMessage = GetRegexMatchingObject()
+            var messageFromIncommingChatMessage = RegexMatchingObject
                 .Match(GetMessageContentsReadyForRegexParsing(incommingChatMessage))
                 .Groups[1]
                 .Value;
 
-            var outboundMessage = "{0} {1}".FormatInline(messageFromIncommingChatMessage, combinedUserNames);
+            var outboundMessage = $"{messageFromIncommingChatMessage} {combinedUserNames}";
             chatRoom.PostMessageOrThrow(outboundMessage);
-        }
-
-        public override string GetActionName()
-        {
-            return "Ping Reviewers";
-        }
-
-        public override string GetActionDescription()
-        {
-            return "The bot will send a message with an @reply to all users that have done reviews recently.";
-        }
-
-        public override string GetActionUsage()
-        {
-            return "ping reviewers <message>";
-        }
-
-        public override ActionPermissionLevel GetPermissionLevel()
-        {
-            return ActionPermissionLevel.Owner;
         }
     }
 }

--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/RefreshTags.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/RefreshTags.cs
@@ -1,17 +1,23 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Text.RegularExpressions;
 
 namespace CVChatbot.Bot.ChatbotActions.Commands
 {
     public class RefreshTags : UserCommand
     {
-        protected override string GetRegexMatchingPattern()
-        {
-            return @"refresh tags";
-        }
+        private Regex ptn = new Regex("^refresh tags$", RegexObjOptions);
+
+        public override string ActionDescription =>
+            "Forces a refresh of the tags obtained from the SEDE query.";
+
+        public override string ActionName => "Refresh Tags";
+
+        public override string ActionUsage => "refresh tags";
+
+        public override ActionPermissionLevel PermissionLevel => ActionPermissionLevel.Registered;
+
+        protected override Regex RegexMatchingObject => ptn;
+
+
 
         public override void RunAction(ChatExchangeDotNet.Message incommingChatMessage, ChatExchangeDotNet.Room chatRoom, InstallationSettings roomSettings)
         {
@@ -25,26 +31,6 @@ namespace CVChatbot.Bot.ChatbotActions.Commands
             }
 
             chatRoom.PostReplyOrThrow(incommingChatMessage, "Tag data has been refreshed.");
-        }
-
-        public override string GetActionName()
-        {
-            return "Refresh Tags";
-        }
-
-        public override string GetActionDescription()
-        {
-            return "Forces a refresh of the tags obtained from the SEDE query.";
-        }
-
-        public override string GetActionUsage()
-        {
-            return "refresh tags";
-        }
-
-        public override ActionPermissionLevel GetPermissionLevel()
-        {
-            return ActionPermissionLevel.Registered;
         }
     }
 }

--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/RunningCommands.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/RunningCommands.cs
@@ -1,14 +1,27 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Text.RegularExpressions;
 using TCL.Extensions;
 
 namespace CVChatbot.Bot.ChatbotActions.Commands
 {
     public class RunningCommands : UserCommand
     {
+        private Regex ptn = new Regex(@"^(show (a |me )?)?(list of |the )?running (commands|actions)( (please|pl[sz]))?$", RegexObjOptions);
+
+        public override string ActionDescription =>
+            "Displays a list of all commands that the chat bot is currently running.";
+
+        public override string ActionName => "Running Commands";
+
+        public override string ActionUsage => "running commands";
+
+        public override ActionPermissionLevel PermissionLevel => ActionPermissionLevel.Everyone;
+
+        protected override Regex RegexMatchingObject => ptn;
+
+
+
         public override void RunAction(ChatExchangeDotNet.Message incommingChatMessage, ChatExchangeDotNet.Room chatRoom, InstallationSettings roomSettings)
         {
             var runningCommands = RunningChatbotActionsManager.GetRunningChatbotActions();
@@ -18,7 +31,7 @@ namespace CVChatbot.Bot.ChatbotActions.Commands
                 .Select(x => new
                 {
                     Command = x.ChatbotActionName,
-                    ForUser = "{0} ({1})".FormatInline(x.RunningForUserName, x.RunningForUserId),
+                    ForUser = $"{x.RunningForUserName} ({x.RunningForUserId})",
                     Started = (now - x.StartTs).ToUserFriendlyString() + " ago",
                 })
                 .ToStringTable(new[] { "Command", "For User", "Started" },
@@ -28,31 +41,6 @@ namespace CVChatbot.Bot.ChatbotActions.Commands
 
             chatRoom.PostReplyOrThrow(incommingChatMessage, "The following is a list of commands that I'm currently running:");
             chatRoom.PostMessageOrThrow(tableMessage);
-        }
-
-        public override ActionPermissionLevel GetPermissionLevel()
-        {
-            return ActionPermissionLevel.Everyone;
-        }
-
-        protected override string GetRegexMatchingPattern()
-        {
-            return @"^(show (a |me )?)?(list of |the )?running (commands|actions)( (please|pl[sz]))?$";
-        }
-
-        public override string GetActionName()
-        {
-            return "Running Commands";
-        }
-
-        public override string GetActionDescription()
-        {
-            return "Displays a list of all commands that the chat bot is currently running.";
-        }
-
-        public override string GetActionUsage()
-        {
-            return "running commands";
         }
     }
 }

--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/StartEvent.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/StartEvent.cs
@@ -1,18 +1,25 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Text.RegularExpressions;
 using TCL.Extensions;
 
 namespace CVChatbot.Bot.ChatbotActions.Commands
 {
     public class StartEvent : UserCommand
     {
-        protected override string GetRegexMatchingPattern()
-        {
-            return "^(pl(ease|[sz]) )?((start(ing)?( the)? event)|(event start(ed)?))( pl(eas|[sz]))?$";
-        }
+        private Regex ptn = new Regex("^(pl(ease|[sz]) )?((start(ing)?( the)? event)|(event start(ed)?))( pl(eas|[sz]))?$", RegexObjOptions);
+
+        public override string ActionDescription =>
+            "Shows the current stats from the /review/close/stats page and the next 3 tags to work on.";
+
+        public override string ActionName => "Start Event";
+
+        public override string ActionUsage => "start event";
+
+        public override ActionPermissionLevel PermissionLevel => ActionPermissionLevel.Owner;
+
+        protected override Regex RegexMatchingObject => ptn;
+
+
 
         public override void RunAction(ChatExchangeDotNet.Message incommingChatMessage, ChatExchangeDotNet.Room chatRoom, InstallationSettings roomSettings)
         {
@@ -31,34 +38,14 @@ namespace CVChatbot.Bot.ChatbotActions.Commands
 
             var topTags = tags
                 .Take(3)
-                .Select(x => "[tag:{0}]".FormatInline(x.Key));
+                .Select(x => $"[tag:{x.Key}]");
 
             var combinedTags = topTags.ToCSV(", ");
 
-            var tagsMessage = "The tags to work on are: {0}.".FormatInline(combinedTags);
+            var tagsMessage = $"The tags to work on are: {combinedTags}.";
 
             chatRoom.PostMessageOrThrow(statsMessage);
             chatRoom.PostMessageOrThrow(tagsMessage);
-        } 
-
-        public override string GetActionName()
-        {
-            return "Start Event";
-        }
-
-        public override string GetActionDescription()
-        {
-            return "Shows the current stats from the /review/close/stats page and the next 3 tags to work on.";
-        }
-
-        public override string GetActionUsage()
-        {
-            return "start event";
-        }
-
-        public override ActionPermissionLevel GetPermissionLevel()
-        {
-            return ActionPermissionLevel.Owner;
         }
     }
 }

--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/StartingSession.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/StartingSession.cs
@@ -1,26 +1,37 @@
-﻿using ChatExchangeDotNet;
-using CVChatbot.Bot.Database;
-using System;
+﻿using CVChatbot.Bot.Database;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using TCL.Extensions;
+using System.Text.RegularExpressions;
 
 namespace CVChatbot.Bot.ChatbotActions.Commands
 {
     public class StartingSession : UserCommand
     {
+        private Regex ptn = new Regex(@"^(?:i'?m )?start(ing|ed)(?: now)?$", RegexObjOptions);
+
+        public override string ActionDescription =>
+            "Informs the chatbot that you are starting a new review session.";
+
+        public override string ActionName => "Starting";
+
+        public override string ActionUsage => "starting";
+
+        public override ActionPermissionLevel PermissionLevel => ActionPermissionLevel.Registered;
+
+        protected override Regex RegexMatchingObject => ptn;
+
+
+
         public override void RunAction(ChatExchangeDotNet.Message incommingChatMessage, ChatExchangeDotNet.Room chatRoom, InstallationSettings roomSettings)
         {
             var chatUser = chatRoom.GetUser(incommingChatMessage.Author.ID);
 
             var da = new DatabaseAccessor(roomSettings.DatabaseConnectionString);
 
-            // first, check if the user has any open sessions, and close them
-            int numberOfClosedSessions = da.EndAnyOpenSessions(incommingChatMessage.Author.ID);
+            // First, check if the user has any open sessions, and close them
+            var numberOfClosedSessions = da.EndAnyOpenSessions(incommingChatMessage.Author.ID);
 
-            // now record the new session
+            // Now record the new session
             da.StartReviewSession(incommingChatMessage.Author.ID);
 
             var replyMessages = new List<string>()
@@ -30,16 +41,15 @@ namespace CVChatbot.Bot.ChatbotActions.Commands
                 "Don't get lost in the queue!",
                 "Watch out for audits!",
                 "May the Vote be with you!",
-                //"May Shog9's Will be done.",
                 "Make a dent!",
                 "By the power of the Vote! Review!"
             };
 
             var outMessage = replyMessages.PickRandom();
 
-            if (numberOfClosedSessions > 0) //if there was a closed session
+            if (numberOfClosedSessions > 0) // If there was a closed session
             {
-                //append a message saying how many there were
+                // Append a message saying how many there were
 
                 outMessage += " **Note:** You had {0} open {1}. I have closed {2}.".FormatInline(
                     numberOfClosedSessions,
@@ -52,31 +62,6 @@ namespace CVChatbot.Bot.ChatbotActions.Commands
             }
 
             chatRoom.PostReplyOrThrow(incommingChatMessage, outMessage);
-        }
-
-        public override ActionPermissionLevel GetPermissionLevel()
-        {
-            return ActionPermissionLevel.Registered;
-        }
-
-        protected override string GetRegexMatchingPattern()
-        {
-            return @"^(?:i'?m )?start(ing|ed)(?: now)?$";
-        }
-
-        public override string GetActionName()
-        {
-            return "Starting";
-        }
-
-        public override string GetActionDescription()
-        {
-            return "Informs the chatbot that you are starting a new review session.";
-        }
-
-        public override string GetActionUsage()
-        {
-            return "starting";
         }
     }
 }

--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/Stats.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/Stats.cs
@@ -1,45 +1,30 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using TCL.Extensions;
+﻿using System.Text.RegularExpressions;
 
 namespace CVChatbot.Bot.ChatbotActions.Commands
 {
     public class Stats : UserCommand
     {
+        private Regex ptn = new Regex("^(close vote )?stats( (please|pl[sz]))?$", RegexObjOptions);
+
+        public override string ActionDescription =>
+            "Shows the stats at the top of the /review/close/stats page.";
+
+        public override string ActionName => "Stats";
+
+        public override string ActionUsage => "stats";
+
+        public override ActionPermissionLevel PermissionLevel => ActionPermissionLevel.Registered;
+
+        protected override Regex RegexMatchingObject => ptn;
+
+
+
         public override void RunAction(ChatExchangeDotNet.Message incommingChatMessage, ChatExchangeDotNet.Room chatRoom, InstallationSettings roomSettings)
         {
             var sa = new CloseQueueStatsAccessor();
             var message = sa.GetOverallQueueStats();
 
             chatRoom.PostMessageOrThrow(message);
-        }
-
-        public override ActionPermissionLevel GetPermissionLevel()
-        {
-            return ActionPermissionLevel.Registered;
-        }
-
-        protected override string GetRegexMatchingPattern()
-        {
-            return "^(close vote )?stats( (please|pl[sz]))?$";
-        }
-
-        public override string GetActionName()
-        {
-            return "Stats";
-        }
-
-        public override string GetActionDescription()
-        {
-            return "Shows the stats at the top of the /review/close/stats page.";
-        }
-
-        public override string GetActionUsage()
-        {
-            return "stats";
         }
     }
 }

--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/Status.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/Status.cs
@@ -1,54 +1,36 @@
-﻿using ChatExchangeDotNet;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Diagnostics;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
-using TCL.Extensions;
+using System.Text.RegularExpressions;
 
 namespace CVChatbot.Bot.ChatbotActions.Commands
 {
     public class Status : UserCommand
     {
+        private Regex ptn = new Regex(@"^((program|chatbot|bot|what'?s your) )?status(\?)?$", RegexObjOptions);
+
+        public override string ActionDescription =>
+            "Tests if the chatbot is alive and shows simple info about it.";
+
+        public override string ActionName => "Status";
+
+        public override string ActionUsage => "status";
+
+        public override ActionPermissionLevel PermissionLevel => ActionPermissionLevel.Everyone;
+
+        protected override Regex RegexMatchingObject => ptn;
+
+
+
         public override void RunAction(ChatExchangeDotNet.Message incommingChatMessage, ChatExchangeDotNet.Room chatRoom, InstallationSettings roomSettings)
         {
             var elapsedTime = DateTime.Now - ChatBotStats.LoginDate;
-
-            Assembly assembly = Assembly.GetExecutingAssembly();
-            FileVersionInfo fvi = FileVersionInfo.GetVersionInfo(assembly.Location);
-            string version = fvi.FileVersion;
-
-            var message = "SOCVR ChatBot version {0}, running for {1}."
-                .FormatInline(version, elapsedTime.ToUserFriendlyString());
+            var assembly = Assembly.GetExecutingAssembly();
+            var fvi = FileVersionInfo.GetVersionInfo(assembly.Location);
+            var version = fvi.FileVersion;
+            var message = $"SOCVR ChatBot version {version}, running for {elapsedTime.ToUserFriendlyString()}.";
 
             chatRoom.PostMessageOrThrow(message);
-        }
-
-        public override ActionPermissionLevel GetPermissionLevel()
-        {
-            return ActionPermissionLevel.Everyone;
-        }
-
-        protected override string GetRegexMatchingPattern()
-        {
-            return @"^((program|chatbot|bot|what'?s your) )?status(\?)?$";
-        }
-
-        public override string GetActionName()
-        {
-            return "Status";
-        }
-
-        public override string GetActionDescription()
-        {
-            return "Tests if the chatbot is alive and shows simple info about it.";
-        }
-
-        public override string GetActionUsage()
-        {
-            return "status";
         }
     }
 }

--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/StopBot.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/StopBot.cs
@@ -1,41 +1,25 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Text.RegularExpressions;
 
 namespace CVChatbot.Bot.ChatbotActions.Commands
 {
     public class StopBot : UserCommand
     {
-        public override void RunAction(ChatExchangeDotNet.Message incommingChatMessage, ChatExchangeDotNet.Room chatRoom, InstallationSettings roomSettings)
-        {
+        private Regex ptn = new Regex("^(stop( bot)?|die|shutdown)$", RegexObjOptions);
+
+        public override string ActionDescription =>
+            "The bot will leave the chat room and quit the running application.";
+
+        public override string ActionName => "Stop Bot";
+
+        public override string ActionUsage => "stop bot";
+
+        public override ActionPermissionLevel PermissionLevel => ActionPermissionLevel.Owner;
+
+        protected override Regex RegexMatchingObject => ptn;
+
+
+
+        public override void RunAction(ChatExchangeDotNet.Message incommingChatMessage, ChatExchangeDotNet.Room chatRoom, InstallationSettings roomSettings) => 
             chatRoom.PostReplyOrThrow(incommingChatMessage, "I'm shutting down...");
-        }
-
-        public override ActionPermissionLevel GetPermissionLevel()
-        {
-            return ActionPermissionLevel.Owner;
-        }
-
-        protected override string GetRegexMatchingPattern()
-        {
-            return "^stop bot$";
-        }
-
-        public override string GetActionName()
-        {
-            return "Stop Bot";
-        }
-
-        public override string GetActionDescription()
-        {
-            return "The bot will leave the chat room and quit the running application.";
-        }
-
-        public override string GetActionUsage()
-        {
-            return "stop bot";
-        }
     }
 }

--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/TrackUser.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/TrackUser.cs
@@ -1,19 +1,28 @@
-﻿using CVChatbot.Bot.Database;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
+﻿using System.Text.RegularExpressions;
+using CVChatbot.Bot.Database;
 using TCL.Extensions;
 
 namespace CVChatbot.Bot.ChatbotActions.Commands
 {
     public class TrackUser : UserCommand
     {
+        private Regex ptn = new Regex(@"^(?:add|track) user (\d+)$", RegexObjOptions);
+
+        public override string ActionDescription => "Adds the user to the registered users list.";
+
+        public override string ActionName => "Add user";
+
+        public override string ActionUsage => "(add | track) user <chat id>";
+
+        public override ActionPermissionLevel PermissionLevel => ActionPermissionLevel.Owner;
+
+        protected override Regex RegexMatchingObject => ptn;
+
+
+
         public override void RunAction(ChatExchangeDotNet.Message incommingChatMessage, ChatExchangeDotNet.Room chatRoom, InstallationSettings roomSettings)
         {
-            var userIdToAdd = GetRegexMatchingObject()
+            var userIdToAdd = RegexMatchingObject
                 .Match(GetMessageContentsReadyForRegexParsing(incommingChatMessage))
                 .Groups[1]
                 .Value
@@ -32,33 +41,7 @@ namespace CVChatbot.Bot.ChatbotActions.Commands
             da.AddUserToRegisteredUsersList(userIdToAdd);
 
             var chatUser = chatRoom.GetUser(userIdToAdd);
-            chatRoom.PostReplyOrThrow(incommingChatMessage, "Ok, I added {0} ({1}) to the tracked users list."
-                .FormatInline(chatUser.Name, chatUser.ID));
-        }
-
-        public override ActionPermissionLevel GetPermissionLevel()
-        {
-            return ActionPermissionLevel.Owner;
-        }
-
-        protected override string GetRegexMatchingPattern()
-        {
-            return @"^(?:add|track) user (\d+)$";
-        }
-
-        public override string GetActionName()
-        {
-            return "Add user";
-        }
-
-        public override string GetActionDescription()
-        {
-            return "Adds the user to the registered users list.";
-        }
-
-        public override string GetActionUsage()
-        {
-            return "(add | track) user <chat id>";
+            chatRoom.PostReplyOrThrow(incommingChatMessage, $"Ok, I added {chatUser.Name} ({chatUser.ID}) to the ---stalked--- tracked users list.");
         }
     }
 }

--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/UserCommand.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/Commands/UserCommand.cs
@@ -1,9 +1,4 @@
 ﻿using ChatExchangeDotNet;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace CVChatbot.Bot.ChatbotActions.Commands
 {
@@ -29,9 +24,6 @@ namespace CVChatbot.Bot.ChatbotActions.Commands
         /// If you want to run a User Command it must be a reply to the chatbot.
         /// </summary>
         /// <returns></returns>
-        protected override bool GetMessageIsReplyToChatbotRequiredValue()
-        {
-            return true;
-        }
+        protected override bool ReplyMessagesOnly => true;
     }
 }

--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/Triggers/CompletedAudit.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/Triggers/CompletedAudit.cs
@@ -1,51 +1,34 @@
-﻿using ChatExchangeDotNet;
+﻿using System.Text.RegularExpressions;
 using CVChatbot.Bot.Database;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace CVChatbot.Bot.ChatbotActions.Triggers
 {
     public class CompletedAudit : Trigger
     {
+        private Regex ptn = new Regex(@"^passed\s+(?:an?\s+)?(\S+)\s+audit$", RegexObjOptions);
+
+        public override string ActionDescription => null;
+
+        public override string ActionName => "Completed Audit";
+
+        public override string ActionUsage => null;
+
+        public override ActionPermissionLevel PermissionLevel => ActionPermissionLevel.Registered;
+
+        protected override Regex RegexMatchingObject => ptn;
+
+
+
         public override void RunAction(ChatExchangeDotNet.Message incommingChatMessage, ChatExchangeDotNet.Room chatRoom, InstallationSettings roomSettings)
         {
             var chatUser = chatRoom.GetUser(incommingChatMessage.Author.ID);
-            var tagName = GetRegexMatchingObject()
+            var tagName = RegexMatchingObject
                     .Match(GetMessageContentsReadyForRegexParsing(incommingChatMessage))
                     .Groups[1]
                     .Value;
 
             var da = new DatabaseAccessor(roomSettings.DatabaseConnectionString);
             da.InsertCompletedAuditEntry(incommingChatMessage.Author.ID, tagName);
-        }
-
-        public override ActionPermissionLevel GetPermissionLevel()
-        {
-            return ActionPermissionLevel.Registered;
-        }
-
-        protected override string GetRegexMatchingPattern()
-        {
-            return @"^passed\s+(?:an?\s+)?(\S+)\s+audit$";
-        }
-
-        public override string GetActionName()
-        {
-            return "Completed Audit";
-        }
-
-        public override string GetActionDescription()
-        {
-            return null;
-        }
-
-        public override string GetActionUsage()
-        {
-            return null;
         }
     }
 }

--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/Triggers/EmptyFilter.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/Triggers/EmptyFilter.cs
@@ -1,26 +1,35 @@
-﻿using ChatExchangeDotNet;
-using CVChatbot.Bot.Database;
-using System;
-using System.Collections.Generic;
+﻿using CVChatbot.Bot.Database;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace CVChatbot.Bot.ChatbotActions.Triggers
 {
     public class EmptyFilter : Trigger
     {
+        private Regex ptn = new Regex("^(?:> +)?there are no items for you to review, matching the filter \"(?:[A-z-, ']+; )?([\\S ]+)\"");
+        private Regex tagMatchingPattern = new Regex(@"\[(\S+?)\] ?", RegexObjOptions);
+
+        public override string ActionDescription => null;
+
+        public override string ActionName => "Empty Filter";
+
+        public override string ActionUsage => null;
+
+        public override ActionPermissionLevel PermissionLevel => ActionPermissionLevel.Registered;
+
+        protected override Regex RegexMatchingObject => ptn;
+
+
+
         public override void RunAction(ChatExchangeDotNet.Message incommingChatMessage, ChatExchangeDotNet.Room chatRoom, InstallationSettings roomSettings)
         {
             // First, get the tags that were used.
-            string tags = GetRegexMatchingObject()
+            string tags = RegexMatchingObject
                     .Match(GetMessageContentsReadyForRegexParsing(incommingChatMessage))
                     .Groups[1]
                     .Value;
 
             // Split out tags.
-            var tagMatchingPattern = new Regex(@"\[(\S+?)\] ?", RegexOptions.CultureInvariant);
             var parsedTagNames = tagMatchingPattern.Matches(incommingChatMessage.Content.ToLower())
                 .Cast<Match>()
                 .Select(x => x.Groups[1].Value)
@@ -33,31 +42,6 @@ namespace CVChatbot.Bot.ChatbotActions.Triggers
             {
                 da.InsertNoItemsInFilterRecord(incommingChatMessage.Author.ID, tagName);
             }
-        }
-
-        public override ActionPermissionLevel GetPermissionLevel()
-        {
-            return ActionPermissionLevel.Registered;
-        }
-
-        protected override string GetRegexMatchingPattern()
-        {
-            return "^(?:> +)?there are no items for you to review, matching the filter \"(?:[A-z-, ']+; )?([\\S ]+)\"";
-        }
-
-        public override string GetActionName()
-        {
-            return "Empty Filter";
-        }
-
-        public override string GetActionDescription()
-        {
-            return null;
-        }
-
-        public override string GetActionUsage()
-        {
-            return null;
         }
     }
 }

--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/Triggers/EndingSessionTrigger.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/Triggers/EndingSessionTrigger.cs
@@ -2,11 +2,6 @@
 using CVChatbot.Bot.ChatbotActions.Commands;
 using CVChatbot.Bot.Database;
 using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using TCL.Extensions;
 
 namespace CVChatbot.Bot.ChatbotActions.Triggers

--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/Triggers/OutOfCloseVotes.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/Triggers/OutOfCloseVotes.cs
@@ -1,16 +1,25 @@
-﻿using CVChatbot.Bot.ChatbotActions.Commands;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
+﻿using System.Text.RegularExpressions;
+using CVChatbot.Bot.ChatbotActions.Commands;
 using TCL.Extensions;
 
 namespace CVChatbot.Bot.ChatbotActions.Triggers
 {
     public class OutOfCloseVotes : EndingSessionTrigger
     {
+        private Regex ptn = new Regex(@"^(?:> +)?you have no more close votes today; come back in (\d+) hours\.?$", RegexObjOptions);
+
+        public override string ActionDescription => null;
+
+        public override string ActionName => "Out of Close Votes";
+
+        public override string ActionUsage => null;
+
+        public override ActionPermissionLevel PermissionLevel => ActionPermissionLevel.Registered;
+
+        protected override Regex RegexMatchingObject => ptn;
+
+
+
         public override void RunAction(ChatExchangeDotNet.Message incommingChatMessage, ChatExchangeDotNet.Room chatRoom, InstallationSettings roomSettings)
         {
             var success = EndSession(incommingChatMessage, chatRoom, null, roomSettings);
@@ -21,31 +30,6 @@ namespace CVChatbot.Bot.ChatbotActions.Triggers
                     .FormatInline(ChatbotActionRegister.GetChatBotActionUsage<LastSessionEditCount>());
                 chatRoom.PostReplyOrThrow(incommingChatMessage, message);
             }
-        }
-
-        public override ActionPermissionLevel GetPermissionLevel()
-        {
-            return ActionPermissionLevel.Registered;
-        }
-
-        protected override string GetRegexMatchingPattern()
-        {
-            return @"^(?:> +)?you have no more close votes today; come back in (\d+) hours\.?$";
-        }
-
-        public override string GetActionName()
-        {
-            return "Out of Close Votes";
-        }
-
-        public override string GetActionDescription()
-        {
-            return null;
-        }
-
-        public override string GetActionUsage()
-        {
-            return null;
         }
     }
 }

--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/Triggers/OutOfReviewActions.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/Triggers/OutOfReviewActions.cs
@@ -1,12 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
-using System.Configuration;
-using TCL.Extensions;
+﻿using TCL.Extensions;
 using CVChatbot.Bot.ChatbotActions.Commands;
+using System.Text.RegularExpressions;
 
 namespace CVChatbot.Bot.ChatbotActions.Triggers
 {
@@ -15,9 +9,23 @@ namespace CVChatbot.Bot.ChatbotActions.Triggers
     /// </summary>
     public class OutOfReviewActions : EndingSessionTrigger
     {
+        private Regex ptn = new Regex(@"^(?:> +)?thank you for reviewing (\d+) close votes today; come back in ([\w ]+) to continue reviewing\.?$", RegexObjOptions);
+
+        public override string ActionDescription => null;
+
+        public override string ActionName => "Out of Review Actions";
+
+        public override string ActionUsage => null;
+
+        public override ActionPermissionLevel PermissionLevel => ActionPermissionLevel.Registered;
+
+        protected override Regex RegexMatchingObject => ptn;
+
+
+
         public override void RunAction(ChatExchangeDotNet.Message incommingChatMessage, ChatExchangeDotNet.Room chatRoom, InstallationSettings roomSettings)
         {
-            var itemsReviewed = GetRegexMatchingObject()
+            var itemsReviewed = RegexMatchingObject
                 .Match(GetMessageContentsReadyForRegexParsing(incommingChatMessage))
                 .Groups[1]
                 .Value
@@ -30,31 +38,6 @@ namespace CVChatbot.Bot.ChatbotActions.Triggers
                 chatRoom.PostReplyOrThrow(incommingChatMessage, "Thanks for reviewing! To see more information use the command `{0}`."
                     .FormatInline(ChatbotActionRegister.GetChatBotActionUsage<LastSessionStats>()));
             }
-        }
-
-        public override ActionPermissionLevel GetPermissionLevel()
-        {
-            return ActionPermissionLevel.Registered;
-        }
-
-        protected override string GetRegexMatchingPattern()
-        {
-            return @"^(?:> +)?thank you for reviewing (\d+) close votes today; come back in ([\w ]+) to continue reviewing\.?$";
-        }
-
-        public override string GetActionName()
-        {
-            return "Out of Review Actions";
-        }
-
-        public override string GetActionDescription()
-        {
-            return null;
-        }
-
-        public override string GetActionUsage()
-        {
-            return null;
         }
     }
 }

--- a/CVChatbot/CVChatbot.Bot/ChatbotActions/Triggers/Trigger.cs
+++ b/CVChatbot/CVChatbot.Bot/ChatbotActions/Triggers/Trigger.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace CVChatbot.Bot.ChatbotActions.Triggers
+﻿namespace CVChatbot.Bot.ChatbotActions.Triggers
 {
     /// <summary>
     /// A Trigger is a message said in chat which is not a direct reply to the chatbot, but the chatbot will take action on the message.
@@ -16,20 +10,14 @@ namespace CVChatbot.Bot.ChatbotActions.Triggers
         /// If you are running a trigger then it can't be a reply to the chatbot.
         /// </summary>
         /// <returns></returns>
-        protected override sealed bool GetMessageIsReplyToChatbotRequiredValue()
-        {
-            return false;
-        }
+        protected override sealed bool ReplyMessagesOnly => false;
 
         /// <summary>
         /// Takes the content from the message and trims the contents. It does not remove or replace anything within the string.
         /// </summary>
         /// <param name="incommingMessage"></param>
         /// <returns></returns>
-        protected override string GetMessageContentsReadyForRegexParsing(ChatExchangeDotNet.Message incommingMessage)
-        {
-            return incommingMessage.Content
-                .Trim();
-        }
+        protected override string GetMessageContentsReadyForRegexParsing(ChatExchangeDotNet.Message incommingMessage) =>
+            incommingMessage.Content.Trim();
     }
 }

--- a/CVChatbot/CVChatbot.Bot/CloseQueueStatsAccessor.cs
+++ b/CVChatbot/CVChatbot.Bot/CloseQueueStatsAccessor.cs
@@ -33,9 +33,9 @@ namespace CVChatbot.Bot
 
             var message = new[]
             {
-                "{0} need review".FormatInline(needReview),
-                "{0} reviews today".FormatInline(reviewsToday),
-                "{0} reviews all-time".FormatInline(allTime),
+                $"{needReview} need review",
+                $"{reviewsToday} reviews today",
+                $"{allTime} reviews all-time",
             }
             .ToCSV(Environment.NewLine);
             return message;

--- a/CVChatbot/CVChatbot.Bot/Database/CompletedTag.cs
+++ b/CVChatbot/CVChatbot.Bot/Database/CompletedTag.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace CVChatbot.Bot.Database
 {

--- a/CVChatbot/CVChatbot.Bot/Database/DatabaseAccessor.cs
+++ b/CVChatbot/CVChatbot.Bot/Database/DatabaseAccessor.cs
@@ -1,11 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using TCL.DataAccess;
 using System.Data;
-using TCL.Extensions;
 
 #if MsSql
 using TCL.DataAccess.MsSql;

--- a/CVChatbot/CVChatbot.Bot/Database/RegisteredUser.cs
+++ b/CVChatbot/CVChatbot.Bot/Database/RegisteredUser.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace CVChatbot.Bot.Database
+﻿namespace CVChatbot.Bot.Database
 {
     class RegisteredUser
     {

--- a/CVChatbot/CVChatbot.Bot/Database/ReviewSession.cs
+++ b/CVChatbot/CVChatbot.Bot/Database/ReviewSession.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace CVChatbot.Bot.Database
 {

--- a/CVChatbot/CVChatbot.Bot/Database/UserAuditStatEntry.cs
+++ b/CVChatbot/CVChatbot.Bot/Database/UserAuditStatEntry.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace CVChatbot.Bot.Database
+﻿namespace CVChatbot.Bot.Database
 {
     class UserAuditStatEntry
     {

--- a/CVChatbot/CVChatbot.Bot/Database/UserCompletedTag.cs
+++ b/CVChatbot/CVChatbot.Bot/Database/UserCompletedTag.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace CVChatbot.Bot.Database
 {

--- a/CVChatbot/CVChatbot.Bot/Extensions.cs
+++ b/CVChatbot/CVChatbot.Bot/Extensions.cs
@@ -26,9 +26,9 @@ namespace CVChatbot.Bot
         /// </remarks>
         internal static string GetInputValue(this CQ input, string elementName)
         {
-            var fkeyE = input["input"].FirstOrDefault(e => e.Attributes["name"] != null && e.Attributes["name"] == elementName);
+            var fkeyE = input["input"].FirstOrDefault(e => e?.Attributes["name"] == elementName);
 
-            return fkeyE == null ? null : fkeyE.Attributes["value"];
+            return fkeyE?.Attributes["value"];
         }
 
         /// <summary>
@@ -36,10 +36,8 @@ namespace CVChatbot.Bot
         /// </summary>
         /// <param name="message">The message to process.</param>
         /// <returns></returns>
-        public static string GetContentsWithStrippedMentions(this Message message)
-        {
-            return ExtensionMethods.StripMention(message.Content);
-        }
+        public static string GetContentsWithStrippedMentions(this Message message) =>
+            ExtensionMethods.StripMention(message.Content);
 
         /// <summary>
         /// Attempts to post the message to the chat room. If the message could not be posted an exception will be thrown.
@@ -62,10 +60,8 @@ namespace CVChatbot.Bot
         /// <param name="chatRoom"></param>
         /// <param name="replyingToMessage"></param>
         /// <param name="message"></param>
-        public static void PostReplyOrThrow(this Room chatRoom, Message replyingToMessage, string message)
-        {
+        public static void PostReplyOrThrow(this Room chatRoom, Message replyingToMessage, string message) =>
             chatRoom.PostReplyOrThrow(replyingToMessage.ID, message);
-        }
 
         /// <summary>
         /// Attempts to post the reply message to the chat room. If the message could not be posted an exception will be thrown.
@@ -192,10 +188,8 @@ namespace CVChatbot.Bot
         /// <param name="columnHeaders"></param>
         /// <param name="valueSelectors"></param>
         /// <returns></returns>
-        public static string ToStringTable<T>(this IEnumerable<T> values, string[] columnHeaders, params Func<T, object>[] valueSelectors)
-        {
-            return ToStringTable(values.ToArray(), columnHeaders, valueSelectors);
-        }
+        public static string ToStringTable<T>(this IEnumerable<T> values, string[] columnHeaders, params Func<T, object>[] valueSelectors) =>
+            ToStringTable(values.ToArray(), columnHeaders, valueSelectors);
 
         /// <summary>
         /// Creates an ascii table from the given array.
@@ -223,7 +217,7 @@ namespace CVChatbot.Bot
                 {
                     object value = valueSelectors[colIndex].Invoke(values[rowIndex - 1]);
 
-                    arrValues[rowIndex, colIndex] = value != null ? value.ToString() : "null";
+                    arrValues[rowIndex, colIndex] =  value?.ToString() ?? "null";
                 }
             }
 
@@ -274,16 +268,14 @@ namespace CVChatbot.Bot
         {
             var maxColumnsWidth = new int[arrValues.GetLength(1)];
             for (int colIndex = 0; colIndex < arrValues.GetLength(1); colIndex++)
+            for (int rowIndex = 0; rowIndex < arrValues.GetLength(0); rowIndex++)
             {
-                for (int rowIndex = 0; rowIndex < arrValues.GetLength(0); rowIndex++)
-                {
-                    int newLength = arrValues[rowIndex, colIndex].Length;
-                    int oldLength = maxColumnsWidth[colIndex];
+                int newLength = arrValues[rowIndex, colIndex].Length;
+                int oldLength = maxColumnsWidth[colIndex];
 
-                    if (newLength > oldLength)
-                    {
-                        maxColumnsWidth[colIndex] = newLength;
-                    }
+                if (newLength > oldLength)
+                {
+                    maxColumnsWidth[colIndex] = newLength;
                 }
             }
 

--- a/CVChatbot/CVChatbot.Bot/RoomManager.cs
+++ b/CVChatbot/CVChatbot.Bot/RoomManager.cs
@@ -43,10 +43,7 @@ namespace CVChatbot.Bot
             }
         }
 
-        public void Dispose()
-        {
-            Dispose(!disposed);
-        }
+        public void Dispose() => Dispose(!disposed);
 
         void cmp_StopBotCommandIssued(object sender, EventArgs e)
         {

--- a/CVChatbot/CVChatbot.Bot/RunningChatbotActionsManager.cs
+++ b/CVChatbot/CVChatbot.Bot/RunningChatbotActionsManager.cs
@@ -55,12 +55,8 @@ namespace CVChatbot.Bot
         /// Returns a listing of all currently running chatbot actions.
         /// </summary>
         /// <returns></returns>
-        public static List<RunningChatbotAction> GetRunningChatbotActions()
-        {
-            return runningChatbotActions
-                .Select(x => x.Value)
-                .ToList();
-        }
+        public static List<RunningChatbotAction> GetRunningChatbotActions() => 
+            runningChatbotActions.Select(x => x.Value).ToList();
     }
 
     /// <summary>

--- a/CVChatbot/CVChatbot.Bot/SedeClient.cs
+++ b/CVChatbot/CVChatbot.Bot/SedeClient.cs
@@ -43,7 +43,7 @@ namespace CVChatbot.Bot
             ThrowWhen.IsNullOrEmpty(email, "email");
             ThrowWhen.IsNullOrEmpty(password, "password");
 
-            login = () => { SEOpenIDLogin(email, password); };
+            login = () => SEOpenIDLogin(email, password);
 
             login.Invoke();
         }
@@ -180,7 +180,7 @@ namespace CVChatbot.Bot
                     jobResult = JsonSerializer.DeserializeFromStream<JobResult>(jobStream);
                     if (jobResult.Captcha)
                     {
-                        Console.WriteLine("captcha requested! not logged in? Attempt: {0}", loginAttemtps);
+                        Console.WriteLine($"Captcha requested! Not logged in? Attempt: {loginAttemtps}");
                         login.Invoke();
                     }
                     else
@@ -285,10 +285,7 @@ namespace CVChatbot.Bot
         /// <summary>
         /// This seems a thin wrapper but this here for future use.
         /// </summary>
-        private string GetCSVQuery(string query)
-        {
-            return Get(query);
-        }
+        private string GetCSVQuery(string query) => Get(query);
 
         /// <summary>
         /// POST to the url the urlencoded data and return the contents as a string.

--- a/CVChatbot/CVChatbot.Bot/ThrowWhen.cs
+++ b/CVChatbot/CVChatbot.Bot/ThrowWhen.cs
@@ -16,7 +16,7 @@ namespace CVChatbot.Bot
         {
             if (String.IsNullOrEmpty(value))
             {
-                throw new ArgumentException(String.Format("'{0}' must not be null or empty.", paramName), paramName);
+                throw new ArgumentException($"'{paramName}' must not be null or empty.", paramName);
             }
         }
     }

--- a/CVChatbot/CVChatbot.Console/Program.cs
+++ b/CVChatbot/CVChatbot.Console/Program.cs
@@ -54,7 +54,7 @@ namespace CVChatbot.Console
 
         static void mng_InformationMessageBroadcasted(string message, string author)
         {
-            WriteToConsole("[{0}] {1}".FormatInline(author, message));
+            WriteToConsole($"[{author}] {message}");
         }
 
         static void mng_ShutdownOrderGiven(object sender, EventArgs e)


### PR DESCRIPTION
To summarise, I've:

 * Used certain features (namely, string interpolation and expression-bodied properties/methods) of C# 6.0 where I feel it brings an improvement (to readability).

 * Removed `ChatbotAction`'s `GetRegexMatchingPattern` and `GetRegexMatchingObject` methods, as I feel they are redundant and can be optimised by using a single new property (`RegexMatchingObject `) which returns a compiled Regex object instead.

 * Removed unused `using` directives.

 * Reorganised all command/trigger classes' members in the following order (as there previously wasn't any order, that I'm aware of anyway): private fields, public properties (sub-ordered alphabetically) and then public methods.

 * Changed all command/trigger methods to properties (besides `RunAction`) and removed the prefix "Get" (I'm still not sure why we were using methods to return simple strings in the first place).