### PR TITLE
Finishing the non-public command argument

### DIFF
--- a/source/SOCVR.Chatbot/ChatRoom/ChatMessageProcessor.cs
+++ b/source/SOCVR.Chatbot/ChatRoom/ChatMessageProcessor.cs
@@ -12,6 +12,7 @@ using System.Text.RegularExpressions;
 using System.Collections.Generic;
 using SOCVR.Chatbot.ChatbotActions.Commands.Admin;
 using System.Reflection;
+using SOCVR.Chatbot.ChatbotActions.Commands.Permission;
 
 namespace SOCVR.Chatbot.ChatRoom
 {
@@ -134,8 +135,24 @@ namespace SOCVR.Chatbot.ChatRoom
                 // Don't have permission, tell the user only if it's a command.
                 if (isReplyToChatbot)
                 {
-                    chatRoom.PostReplyOrThrow(incomingChatMessage,
-                        $"Sorry, you are not in the {chatbotActionToRun.RequiredPermissionGroup.ToString()} permission group. Do you want to request access? (reply with 'yes')");
+                    //a person can be denied a command for one of two reasons:
+                    // 1) they are not in the required permission group
+                    // 2) they are not in ANY permission groups
+                    // this is dependent on the command they try to run
+
+                    if (chatbotActionToRun.RequiredPermissionGroup != null)
+                    {
+                        //the command required a specific group which the user was not a part of
+                        chatRoom.PostReplyOrThrow(incomingChatMessage,
+                            $"Sorry, you are not in the {chatbotActionToRun.RequiredPermissionGroup.ToString()} permission group. Do you want to request access? (reply with 'yes')");
+                    }
+                    else
+                    {
+                        //the command can be ran by anyone who is in at least one permission group,
+                        //but this user is not in any
+                        chatRoom.PostReplyOrThrow(incomingChatMessage,
+                            $"Sorry, you need to be in at least one permission group to run this command. Run `{ChatbotActionRegister.GetChatBotActionUsage<Membership>()}` to see the list of groups.");
+                    }
                 }
                 // Don't do anything for triggers.
             }

--- a/source/SOCVR.Chatbot/ChatbotActions/ChatbotAction.cs
+++ b/source/SOCVR.Chatbot/ChatbotActions/ChatbotAction.cs
@@ -94,5 +94,13 @@ namespace SOCVR.Chatbot.ChatbotActions
         /// </summary>
         /// <returns></returns>
         public abstract PermissionGroup? RequiredPermissionGroup { get; }
+
+        /// <summary>
+        /// If true, the user needs to be in at least one permission group to run the command.
+        /// If false, the user does not need to be in any permission groups.
+        /// This is used when commands are "non-public" - they are not tied to any particular
+        /// permission group but they require that you be in at least one of the groups.
+        /// </summary>
+        public abstract bool UserMustBeInAnyPermissionGroupToRun { get; }
     }
 }

--- a/source/SOCVR.Chatbot/ChatbotActions/Commands/Admin/AddReview.cs
+++ b/source/SOCVR.Chatbot/ChatbotActions/Commands/Admin/AddReview.cs
@@ -19,6 +19,8 @@ namespace SOCVR.Chatbot.ChatbotActions.Commands.Admin
 
         public override PermissionGroup? RequiredPermissionGroup => PermissionGroup.BotOwner;
 
+        public override bool UserMustBeInAnyPermissionGroupToRun => true;
+
         protected override string RegexMatchingPattern => @"^add review (\d+) (\d+)$";
 
         public override void RunAction(Message incomingChatMessage, Room chatRoom)

--- a/source/SOCVR.Chatbot/ChatbotActions/Commands/Admin/PingReviewers.cs
+++ b/source/SOCVR.Chatbot/ChatbotActions/Commands/Admin/PingReviewers.cs
@@ -17,6 +17,8 @@ namespace SOCVR.Chatbot.ChatbotActions.Commands.Admin
 
         public override PermissionGroup? RequiredPermissionGroup => PermissionGroup.BotOwner;
 
+        public override bool UserMustBeInAnyPermissionGroupToRun => true;
+
         protected override string RegexMatchingPattern => "^ping reviewers(.+)$";
 
         public override void RunAction(Message incomingChatMessage, Room chatRoom)

--- a/source/SOCVR.Chatbot/ChatbotActions/Commands/Admin/StartEvent.cs
+++ b/source/SOCVR.Chatbot/ChatbotActions/Commands/Admin/StartEvent.cs
@@ -18,6 +18,8 @@ namespace SOCVR.Chatbot.ChatbotActions.Commands.Admin
 
         public override PermissionGroup? RequiredPermissionGroup => PermissionGroup.BotOwner;
 
+        public override bool UserMustBeInAnyPermissionGroupToRun => true;
+
         protected override string RegexMatchingPattern => "^(pl(ease|[sz]) )?((start(ing)?( the)? event)|(event start(ed)?))( pl(eas|[sz]))?$";
 
         public override void RunAction(ChatExchangeDotNet.Message incomingChatMessage, ChatExchangeDotNet.Room chatRoom)

--- a/source/SOCVR.Chatbot/ChatbotActions/Commands/Admin/StopBot.cs
+++ b/source/SOCVR.Chatbot/ChatbotActions/Commands/Admin/StopBot.cs
@@ -14,6 +14,8 @@ namespace SOCVR.Chatbot.ChatbotActions.Commands.Admin
 
         public override PermissionGroup? RequiredPermissionGroup => PermissionGroup.BotOwner;
 
+        public override bool UserMustBeInAnyPermissionGroupToRun => true;
+
         protected override string RegexMatchingPattern => "^(stop( bot)?|die|shutdown)$";
 
         public override void RunAction(Message incomingChatMessage, Room chatRoom) => 

--- a/source/SOCVR.Chatbot/ChatbotActions/Commands/Permission/AddUserToGroup.cs
+++ b/source/SOCVR.Chatbot/ChatbotActions/Commands/Permission/AddUserToGroup.cs
@@ -20,6 +20,8 @@ namespace SOCVR.Chatbot.ChatbotActions.Commands.Permission
 
         public override PermissionGroup? RequiredPermissionGroup => null;
 
+        public override bool UserMustBeInAnyPermissionGroupToRun => true;
+
         protected override string RegexMatchingPattern => @"^add (\d+) to ([\w ]+)$";
 
         public override void RunAction(Message incomingChatMessage, Room chatRoom)

--- a/source/SOCVR.Chatbot/ChatbotActions/Commands/Permission/ApproveRequest.cs
+++ b/source/SOCVR.Chatbot/ChatbotActions/Commands/Permission/ApproveRequest.cs
@@ -12,8 +12,9 @@ namespace SOCVR.Chatbot.ChatbotActions.Commands.Permission
 
         public override string ActionUsage => "approve request [#]";
 
-#warning this command needs a non-public permission group. "null" doesn't really work, but it can slide for now.
         public override PermissionGroup? RequiredPermissionGroup => null;
+
+        public override bool UserMustBeInAnyPermissionGroupToRun => true;
 
         protected override string RegexMatchingPattern => @"^approve request (\d+)$";
 

--- a/source/SOCVR.Chatbot/ChatbotActions/Commands/Permission/Membership.cs
+++ b/source/SOCVR.Chatbot/ChatbotActions/Commands/Permission/Membership.cs
@@ -15,6 +15,8 @@ namespace SOCVR.Chatbot.ChatbotActions.Commands.Permission
 
         public override PermissionGroup? RequiredPermissionGroup => null;
 
+        public override bool UserMustBeInAnyPermissionGroupToRun => false;
+
         protected override string RegexMatchingPattern => @"^membership$";
 
         public override void RunAction(ChatExchangeDotNet.Message incomingChatMessage, ChatExchangeDotNet.Room chatRoom)

--- a/source/SOCVR.Chatbot/ChatbotActions/Commands/Permission/RejectRequest.cs
+++ b/source/SOCVR.Chatbot/ChatbotActions/Commands/Permission/RejectRequest.cs
@@ -11,8 +11,9 @@ namespace SOCVR.Chatbot.ChatbotActions.Commands.Permission
 
         public override string ActionUsage => "reject request [#]";
 
-#warning this command needs a non-public permission group. "null" doesn't really work, but it can slide for now.
         public override PermissionGroup? RequiredPermissionGroup => null;
+
+        public override bool UserMustBeInAnyPermissionGroupToRun => true;
 
         protected override string RegexMatchingPattern => @"^reject request (\d+)$";
 

--- a/source/SOCVR.Chatbot/ChatbotActions/Commands/Permission/RemoveUserFromGroup.cs
+++ b/source/SOCVR.Chatbot/ChatbotActions/Commands/Permission/RemoveUserFromGroup.cs
@@ -20,6 +20,8 @@ namespace SOCVR.Chatbot.ChatbotActions.Commands.Permission
 
         public override PermissionGroup? RequiredPermissionGroup => null;
 
+        public override bool UserMustBeInAnyPermissionGroupToRun => true;
+
         protected override string RegexMatchingPattern => @"^remove (\d+) from ([\w ]+)$";
 
         public override void RunAction(Message incomingChatMessage, Room chatRoom)

--- a/source/SOCVR.Chatbot/ChatbotActions/Commands/Permission/RequestPermissionToGroup.cs
+++ b/source/SOCVR.Chatbot/ChatbotActions/Commands/Permission/RequestPermissionToGroup.cs
@@ -20,6 +20,8 @@ namespace SOCVR.Chatbot.ChatbotActions.Commands.Permission
 
         public override PermissionGroup? RequiredPermissionGroup => null;
 
+        public override bool UserMustBeInAnyPermissionGroupToRun => false;
+
         protected override string RegexMatchingPattern => @"^request permission to (\w+)$";
 
         public override void RunAction(Message incomingChatMessage, Room chatRoom)

--- a/source/SOCVR.Chatbot/ChatbotActions/Commands/Permission/ViewRequests.cs
+++ b/source/SOCVR.Chatbot/ChatbotActions/Commands/Permission/ViewRequests.cs
@@ -18,6 +18,8 @@ namespace SOCVR.Chatbot.ChatbotActions.Commands.Permission
 
         public override PermissionGroup? RequiredPermissionGroup => null;
 
+        public override bool UserMustBeInAnyPermissionGroupToRun => true;
+
         protected override string RegexMatchingPattern => @"^view requests$";
 
         public override void RunAction(ChatExchangeDotNet.Message incomingChatMessage, ChatExchangeDotNet.Room chatRoom)

--- a/source/SOCVR.Chatbot/ChatbotActions/Commands/Stats/AuditStats.cs
+++ b/source/SOCVR.Chatbot/ChatbotActions/Commands/Stats/AuditStats.cs
@@ -15,6 +15,8 @@ namespace SOCVR.Chatbot.ChatbotActions.Commands.Stats
 
         public override PermissionGroup? RequiredPermissionGroup => PermissionGroup.Reviewer;
 
+        public override bool UserMustBeInAnyPermissionGroupToRun => true;
+
         protected override string RegexMatchingPattern => "^audit stats$";
 
         public override void RunAction(Message incomingChatMessage, Room chatRoom)

--- a/source/SOCVR.Chatbot/ChatbotActions/Commands/Stats/ReviewsToday.cs
+++ b/source/SOCVR.Chatbot/ChatbotActions/Commands/Stats/ReviewsToday.cs
@@ -16,6 +16,8 @@ namespace SOCVR.Chatbot.ChatbotActions.Commands.Stats
 
         public override PermissionGroup? RequiredPermissionGroup => PermissionGroup.Reviewer;
 
+        public override bool UserMustBeInAnyPermissionGroupToRun => true;
+
         protected override string RegexMatchingPattern => @"^reviews today(?: (details))?$";
 
         public override void RunAction(Message incomingChatMessage, Room chatRoom)

--- a/source/SOCVR.Chatbot/ChatbotActions/Commands/Stats/Stats.cs
+++ b/source/SOCVR.Chatbot/ChatbotActions/Commands/Stats/Stats.cs
@@ -15,6 +15,8 @@ namespace SOCVR.Chatbot.ChatbotActions.Commands.Stats
 
         public override PermissionGroup? RequiredPermissionGroup => PermissionGroup.Reviewer;
 
+        public override bool UserMustBeInAnyPermissionGroupToRun => true;
+
         protected override string RegexMatchingPattern => "^(close vote )?stats( (please|pl[sz]))?$";
 
         public override void RunAction(ChatExchangeDotNet.Message incomingChatMessage, ChatExchangeDotNet.Room chatRoom)

--- a/source/SOCVR.Chatbot/ChatbotActions/Commands/Stats/TotalReviewsToday.cs
+++ b/source/SOCVR.Chatbot/ChatbotActions/Commands/Stats/TotalReviewsToday.cs
@@ -19,6 +19,8 @@ namespace SOCVR.Chatbot.ChatbotActions.Commands.Stats
 
         public override PermissionGroup? RequiredPermissionGroup => PermissionGroup.Reviewer;
 
+        public override bool UserMustBeInAnyPermissionGroupToRun => true;
+
         protected override string RegexMatchingPattern => "^total reviews today$";
 
         public override void RunAction(Message incomingChatMessage, Room chatRoom)

--- a/source/SOCVR.Chatbot/ChatbotActions/Commands/Tags/CurrentTag.cs
+++ b/source/SOCVR.Chatbot/ChatbotActions/Commands/Tags/CurrentTag.cs
@@ -19,6 +19,8 @@ namespace SOCVR.Chatbot.ChatbotActions.Commands.Tags
 
         public override PermissionGroup? RequiredPermissionGroup => PermissionGroup.Reviewer;
 
+        public override bool UserMustBeInAnyPermissionGroupToRun => true;
+
         protected override string RegexMatchingPattern => @"^(what is the )?current tag( pl(ease|[sz]))?\??$";
 
         public override void RunAction(ChatExchangeDotNet.Message incomingChatMessage, ChatExchangeDotNet.Room chatRoom)

--- a/source/SOCVR.Chatbot/ChatbotActions/Commands/Tags/NextTags.cs
+++ b/source/SOCVR.Chatbot/ChatbotActions/Commands/Tags/NextTags.cs
@@ -17,6 +17,8 @@ namespace SOCVR.Chatbot.ChatbotActions.Commands.Tags
 
         public override PermissionGroup? RequiredPermissionGroup => PermissionGroup.Reviewer;
 
+        public override bool UserMustBeInAnyPermissionGroupToRun => true;
+
         protected override string RegexMatchingPattern => @"^next(?: (\d+))? tags$";
 
         public override void RunAction(ChatExchangeDotNet.Message incomingChatMessage, ChatExchangeDotNet.Room chatRoom)

--- a/source/SOCVR.Chatbot/ChatbotActions/Commands/Tags/RefreshTags.cs
+++ b/source/SOCVR.Chatbot/ChatbotActions/Commands/Tags/RefreshTags.cs
@@ -15,6 +15,8 @@ namespace SOCVR.Chatbot.ChatbotActions.Commands.Tags
 
         public override PermissionGroup? RequiredPermissionGroup => PermissionGroup.Reviewer;
 
+        public override bool UserMustBeInAnyPermissionGroupToRun => true;
+
         protected override string RegexMatchingPattern => "^refresh tags$";
 
         public override void RunAction(ChatExchangeDotNet.Message incomingChatMessage, ChatExchangeDotNet.Room chatRoom)

--- a/source/SOCVR.Chatbot/ChatbotActions/Commands/Tracking/OptIn.cs
+++ b/source/SOCVR.Chatbot/ChatbotActions/Commands/Tracking/OptIn.cs
@@ -19,6 +19,8 @@ namespace SOCVR.Chatbot.ChatbotActions.Commands.Tracking
 
         public override PermissionGroup? RequiredPermissionGroup => PermissionGroup.Reviewer;
 
+        public override bool UserMustBeInAnyPermissionGroupToRun => true;
+
         protected override string RegexMatchingPattern => "^opt[ -]in$";
 
         protected override bool GetOptValue() => true;

--- a/source/SOCVR.Chatbot/ChatbotActions/Commands/Tracking/OptOut.cs
+++ b/source/SOCVR.Chatbot/ChatbotActions/Commands/Tracking/OptOut.cs
@@ -18,6 +18,8 @@ namespace SOCVR.Chatbot.ChatbotActions.Commands.Tracking
 
         public override PermissionGroup? RequiredPermissionGroup => PermissionGroup.Reviewer;
 
+        public override bool UserMustBeInAnyPermissionGroupToRun => true;
+
         protected override string RegexMatchingPattern => "^opt[ -]out$";
 
         protected override bool GetOptValue() => false;

--- a/source/SOCVR.Chatbot/ChatbotActions/Commands/Utilities/Alive.cs
+++ b/source/SOCVR.Chatbot/ChatbotActions/Commands/Utilities/Alive.cs
@@ -14,6 +14,8 @@ namespace SOCVR.Chatbot.ChatbotActions.Commands.Utilities
 
         public override PermissionGroup? RequiredPermissionGroup => null;
 
+        public override bool UserMustBeInAnyPermissionGroupToRun => false;
+
         protected override string RegexMatchingPattern => @"^(?:(?:are )?you )?(alive|still there|(still )?with us)\??$";
 
         public override void RunAction(ChatExchangeDotNet.Message incomingChatMessage, ChatExchangeDotNet.Room chatRoom)

--- a/source/SOCVR.Chatbot/ChatbotActions/Commands/Utilities/Commands.cs
+++ b/source/SOCVR.Chatbot/ChatbotActions/Commands/Utilities/Commands.cs
@@ -21,6 +21,8 @@ namespace SOCVR.Chatbot.ChatbotActions.Commands.Utilities
 
         public override PermissionGroup? RequiredPermissionGroup => null;
 
+        public override bool UserMustBeInAnyPermissionGroupToRun => false;
+
         protected override string RegexMatchingPattern => "^commands(?: (full))?$";
 
         private static class ReflectiveEnumerator

--- a/source/SOCVR.Chatbot/ChatbotActions/Commands/Utilities/Help.cs
+++ b/source/SOCVR.Chatbot/ChatbotActions/Commands/Utilities/Help.cs
@@ -14,6 +14,8 @@ namespace SOCVR.Chatbot.ChatbotActions.Commands.Utilities
 
         public override PermissionGroup? RequiredPermissionGroup => null;
 
+        public override bool UserMustBeInAnyPermissionGroupToRun => false;
+
         protected override string RegexMatchingPattern => "^(i need )?(help|assistance|halp|an adult)( me)?( (please|pl[sz]))?$";
 
         public override void RunAction(Message incomingChatMessage, Room chatRoom)

--- a/source/SOCVR.Chatbot/ChatbotActions/Commands/Utilities/RunningCommands.cs
+++ b/source/SOCVR.Chatbot/ChatbotActions/Commands/Utilities/RunningCommands.cs
@@ -17,6 +17,8 @@ namespace SOCVR.Chatbot.ChatbotActions.Commands.Utilities
 
         public override PermissionGroup? RequiredPermissionGroup => null;
 
+        public override bool UserMustBeInAnyPermissionGroupToRun => false;
+
         protected override string RegexMatchingPattern => @"^(show (a |me )?)?(list of |the )?running (commands|actions)( (please|pl[sz]))?$";
 
         public override void RunAction(Message incomingChatMessage, ChatExchangeDotNet.Room chatRoom)

--- a/source/SOCVR.Chatbot/ChatbotActions/Commands/Utilities/Status.cs
+++ b/source/SOCVR.Chatbot/ChatbotActions/Commands/Utilities/Status.cs
@@ -16,6 +16,8 @@ namespace SOCVR.Chatbot.ChatbotActions.Commands.Utilities
 
         public override PermissionGroup? RequiredPermissionGroup => null;
 
+        public override bool UserMustBeInAnyPermissionGroupToRun => false;
+
         protected override string RegexMatchingPattern => @"^status\??$";
 
         public override void RunAction(ChatExchangeDotNet.Message incomingChatMessage, ChatExchangeDotNet.Room chatRoom)


### PR DESCRIPTION
Every `ChatbotAction` now has a `UserMustBeInAnyPermissionGroupToRun` property.

This property and the `RequiredPermissionGroup` work together to figure out if the user has permission to run an action or not.

Fixes #123